### PR TITLE
Blocks 43 - parsing user variable properly

### DIFF
--- a/src/js/parser/parser.js
+++ b/src/js/parser/parser.js
@@ -78,7 +78,7 @@ const SUB_END = "\n</statement>";
 let XML = "";
 
 // global log enable switch
-const DEBUG = true;
+const DEBUG = false;
 
 /**
  * Catblocks debug function
@@ -151,9 +151,9 @@ function parseCatroidProgram(xml) {
   for (let i = 0; i < scenes.length; i++) {
     sceneList.push(parseScenes(scenes[i]));
   }
-  console.log(sceneList);
+  catLog(sceneList);
   const xmlStream = generateShareXml();
-  // console.log(xmlStream);
+  catLog(xmlStream);
   try {
     return (new DOMParser()).parseFromString(xmlStream, 'text/xml');
   } catch (e) {

--- a/src/js/parser/parser.js
+++ b/src/js/parser/parser.js
@@ -78,7 +78,7 @@ const SUB_END = "\n</statement>";
 let XML = "";
 
 // global log enable switch
-const DEBUG = false;
+const DEBUG = true;
 
 /**
  * Catblocks debug function
@@ -151,7 +151,7 @@ function parseCatroidProgram(xml) {
   for (let i = 0; i < scenes.length; i++) {
     sceneList.push(parseScenes(scenes[i]));
   }
-  // console.log(sceneList);
+  console.log(sceneList);
   const xmlStream = generateShareXml();
   // console.log(xmlStream);
   try {
@@ -258,7 +258,6 @@ const getNodeValueOrDefault = (node, def = "---") => {
 
 function checkUsage(list, location) {
   if (list.nodeName === "broadcastMessage" || list.nodeName === "spriteToBounceOffName" || list.nodeName === "receivedMessage" || list.nodeName === "sceneToStart" || list.nodeName === "sceneForTransition") {
-    // BLOCKS-54 -> sceneForTransition can exist without node child
     location.formValues.set("DROPDOWN", getNodeValueOrDefault(list.childNodes[0]));
   }
   if (list.nodeName === "spinnerSelection") {
@@ -289,10 +288,10 @@ function checkUsage(list, location) {
     const loopOrIfBrickList = (list.children);
     for (let j = 0; j < loopOrIfBrickList.length; j++) {
       location.loopOrIfBrickList.push(parseBrick(loopOrIfBrickList[j]));
-      if(location.name === loopOrIfBrickList[j].name){
-        if(loopOrIfBrickList[j].colorVariation === 0){
+      if (location.name === loopOrIfBrickList[j].name) {
+        if (loopOrIfBrickList[j].colorVariation === 0) {
           location.colorVariation = 1;
-        }else{
+        } else {
           location.colorVariation = 0;
         }
       }
@@ -302,10 +301,10 @@ function checkUsage(list, location) {
     const elseBrickList = (list.children);
     for (let j = 0; j < elseBrickList.length; j++) {
       location.elseBrickList.push(parseBrick(elseBrickList[j]));
-      if(location.name === elseBrickList[j].name){
-        if(elseBrickList[j].colorVariation === 0){
+      if (location.name === elseBrickList[j].name) {
+        if (elseBrickList[j].colorVariation === 0) {
           location.colorVariation = 1;
-        }else{
+        } else {
           location.colorVariation = 0;
         }
       }
@@ -322,100 +321,10 @@ function checkUsage(list, location) {
     location.formValues.set("look", lookName);
   }
   if (list.nodeName === "userVariable") {
-    if (list.childNodes.length !== 0) {
-      findCurrentVariableName(list, location);
-    }
-    else {
-      const reference = list.getAttribute("reference");
-      findOtherVariableName(list, location, reference);
-
-    }
-
-  }
-}
-
-function findCurrentVariableName(list, location) {
-  for (let i = 0; i < list.childNodes.length; i++) {
-    if (list.childNodes[i].nodeName === "userVariable") {
-      const userVariable = list.childNodes[i];
-      for (let j = 0; j < userVariable.childNodes.length; j++) {
-        if (userVariable.childNodes[j].nodeName === "default") {
-          const defaultBlock = userVariable.childNodes[j];
-          for (let k = 0; k < defaultBlock.childNodes.length; k++) {
-            if (defaultBlock.childNodes[k].nodeName === "name") {
-              location.formValues.set("DROPDOWN", defaultBlock.childNodes[k].textContent);
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-function findOtherVariableName(list, location, reference) {
-  if (reference.startsWith("../")) {
-    reference = reference.slice(3);
-    findOtherVariableName(list.parentElement, location, reference);
-  }
-  else if (reference.startsWith("userVariable")) {
-    for (let i = 0; i < list.childNodes.length; i++) {
-      if (list.childNodes[i].nodeName === "userVariable") {
-        findCurrentVariableName(list.childNodes[i], location);
-      }
-    }
-  } else if (reference.startsWith("ifBranchBricks")) {
-    reference = reference.slice(20);
-    let position = 1;
-    if (reference.startsWith("[")) {
-      position = reference.charAt(1);
-      reference = reference.slice(3);
-    }
-    reference = reference.slice(1);
-    for (let i = 0; i < list.childNodes.length; i++) {
-      if (list.childNodes[i].nodeName === "ifBranchBricks") {
-        list = list.childNodes[i].childNodes[(position * 2) - 1];
-        findOtherVariableName(list, location, reference);
-      }
-    }
-  } else if (reference.startsWith("elseBranchBricks")) {
-    reference = reference.slice(22);
-    let position = 1;
-    if (reference.startsWith("[")) {
-      position = reference.charAt(1);
-      reference = reference.slice(3);
-    }
-    reference = reference.slice(1);
-    for (let i = 0; i < list.childNodes.length; i++) {
-      if (list.childNodes[i].nodeName === "elseBranchBricks") {
-        list = list.childNodes[i].childNodes[(position * 2) - 1];
-        findOtherVariableName(list, location, reference);
-      }
-    }
-  } else if (reference.startsWith("script")) {
-    reference = reference.slice(6);
-    let position = 1;
-    if (reference.startsWith("[")) {
-      position = reference.charAt(1);
-      reference = reference.slice(3);
-    }
-    reference = reference.slice(1);
-    findOtherVariableName(list.childNodes[(position * 2) - 1], location, reference);
-
-
-  } else if (reference.startsWith("brickList")) {
-    reference = reference.slice(15);
-    let position = 1;
-    if (reference.startsWith("[")) {
-      position = reference.charAt(1);
-      reference = reference.slice(3);
-    }
-    reference = reference.slice(1);
-    for (let i = 0; i < list.childNodes.length; i++) {
-      if (list.childNodes[i].nodeName === "brickList") {
-        list = list.childNodes[i].childNodes[(position * 2) - 1];
-        findOtherVariableName(list, location, reference);
-      }
-    }
+    const variable = flatReference(list);
+    const variableName = (variable.querySelector('userVariable default name')) ?
+      variable.querySelector('userVariable default name').textContent : 'userVariable';
+    location.formValues.set('DROPDOWN', variableName);
   }
 }
 
@@ -551,6 +460,7 @@ export default class Parser {
     try {
       return (new DOMParser()).parseFromString(XML, 'text/xml');
     } catch (e) {
+      catLog(e);
       console.error('Failed to convert catblocks script into XMLDocument, verify input');
       return;
     }
@@ -567,6 +477,7 @@ export default class Parser {
         const xml = (new window.DOMParser()).parseFromString(scriptString, 'text/xml');
         return Parser.convertScript(xml);
       } catch (e) {
+        catLog(e);
         console.error(`Failed to convert catroid script given as string into a XMLDocument, please verify that the string is a valid program`);
         return undefined;
       }
@@ -588,6 +499,7 @@ export default class Parser {
         initParser(xml);
         return parseCatroidProgram(xml);
       } catch (e) {
+        catLog(e);
         console.error(`Failed to convert catroid program given as string into a XMLDocument, please verify that the string is a valid program`);
         return undefined;
       }
@@ -608,7 +520,7 @@ export default class Parser {
       })
       .catch(err => {
         console.error(`Failed to fetch uri: ${uri}`);
-        console.error(err);
+        catLog(err);
         return undefined;
       });
   }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -228,4 +228,90 @@ describe('Catroid to Catblocks parser tests', () => {
         && catXml.getElementsByTagName('block')[2].getAttribute('type') === 'PlaySoundAndWaitBrick')
     })).toBeTruthy();
   });
+
+  describe('UserVariable parsing', () => {
+    /** 
+     * Test if parser handles local uservariables properly
+     */
+    test('Test of local uservariable parsing', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.includes('tUserVariable'));
+      })).toBeTruthy();
+    });
+
+    /** 
+     * Test if parser handles local uservariable with empty name tag
+     */
+    test('Test of local empty name uservariable parsing', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.length === 0);
+      })).toBeTruthy();
+    });
+
+    /** 
+     * Test if parser handles local uservariable without name tag
+     */
+    test('Test of local uservariable parsing without name tag', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.length === 0);
+      })).toBeTruthy();
+    });
+
+    /** 
+    * Test if parser handles local uservariable without name tag
+    */
+    test('Test of remote uservariable parsing', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.includes('tUserVariable'));
+      })).toBeTruthy();
+    });
+
+    /** 
+     * Test if parser handles local uservariable with empty name tag
+     */
+    test('Test of remote empty name uservariable parsing', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.length === 0);
+      })).toBeTruthy();
+    });
+
+    /** 
+     * Test if parser handles local uservariable without name tag
+     */
+    test('Test of remote uservariable parsing without name tag', async () => {
+      expect(await page.evaluate(() => {
+        const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
+        const catXml = parser.convertScriptString(xmlString);
+
+        if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+        const testValue = catXml.evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null).iterateNext();
+        return (testValue !== undefined && testValue.innerHTML.length === 0);
+      })).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
Fixed catroid to catblocks parser to support user variables. User variable name shows now up inside the dropdown field. User variable can be either inside the current brick or defined via a reference.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
