### PR TITLE
BLOCKS-72 In browser rendering does not work properly

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -109,7 +109,28 @@ h1 {
   color: darkgreen;
 }
 
-#dropper-loader {
+#loading-overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.3);
+  display: none;
+}
+
+#loading-overlay .loading-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loader-icon {
   border: 16px solid #f3f3f3;
   border-top: 16px solid #3498db;
   border-radius: 50%;
@@ -125,4 +146,38 @@ h1 {
 
 .hidden {
   display: none;
+}
+
+
+/* message box */
+.message-box {
+  position: fixed;
+  display: none;
+
+  left: 0;
+  right: 0;
+  bottom: 0;
+  min-width: 300px;
+  width: 50%;
+  max-width: 800px;
+  margin: auto;
+  margin-bottom: 40px;
+  padding: 20px;
+
+  background-color: #f5faff;
+  border-color: #0a6ed1;
+  color: #32363a;
+  box-shadow: 0 0 0 0.0625rem rgba(0,0,0,0.42), 0 0.625rem 1.875rem 0 rgba(0,0,0,0.3);
+  font-size: 0.9em;
+}
+
+.message-box ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+
+.message-box li {
+  padding: 5px;
 }

--- a/src/html/render.html
+++ b/src/html/render.html
@@ -16,10 +16,14 @@
       <label for="dropper-file-input"><strong>Choose a file</strong> or drag it here.</label>
       <span class="small">Only .catrobat Files supported</span>
     </div>
-    <div id="dropper-loader" class="hidden"></div>
   </div>
   <div id="catblocks-workspace-container"></div>
   <div id="catblocks-programs-container"></div>
+  <div id="loading-overlay">
+    <div class="loading-inner">
+      <div class="loader-icon"></div>
+    </div>
+  </div>
 </body>
 
 </html>

--- a/src/js/render/message_box.js
+++ b/src/js/render/message_box.js
@@ -1,0 +1,51 @@
+
+import $ from "jquery";
+
+const DISPLAY_DURATION = 10000;
+const CONTAINER_ID = 'catblocks-message-container';
+const messages = [];
+
+export class MessageBox {
+
+  static show(message) {
+    messages.push(message);
+    MessageBox._render();
+
+    setTimeout(() => {
+      messages.shift();
+      MessageBox._render();
+    }, DISPLAY_DURATION);
+  }
+
+  static _render() {
+    if (messages.length === 0) {
+      $(`#${CONTAINER_ID}`).fadeOut("slow", () => {
+        $(`#${CONTAINER_ID}`).remove();
+      });
+
+    } else if ($(`#${CONTAINER_ID}`).length) {
+      const $ul = $('<ul/>');
+      for (const msg of messages) {
+        const $li = $(`<li>${msg}</li>`);
+        $ul.prepend($li);
+      }
+      $(`#${CONTAINER_ID}`).html($ul);
+
+    } else {
+      const $div = $('<div />', {
+        id: CONTAINER_ID,
+        class: 'message-box'
+      });
+
+      const $ul = $('<ul/>');
+      for (const msg of messages) {
+        const $li = $(`<li>${msg}</li>`);
+        $ul.prepend($li);
+      }
+
+      $div.append($ul);
+      $('body').append($div);
+      $(`#${CONTAINER_ID}`).fadeIn("slow");
+    }
+  }
+}


### PR DESCRIPTION
Add ability to read file type from head of file. Ignore unsupported or unneeded files and continue with rendering. Display info message for unsupported files.
https://jira.catrob.at/browse/BLOCKS-72

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
