### PR TITLE
BLOCKS-60 Parser does not wrap properly RepeatBrick - LoopEndBrick combination

### DIFF
--- a/src/js/parser/parser.js
+++ b/src/js/parser/parser.js
@@ -235,12 +235,11 @@ function parseScripts(script) {
     if(brickList[i].attributes[0].value === "RepeatBrick") {
       currentScript.brickList.push(parseBrick(brickList[i]));
       const position = i;
+      i++;
       while(brickList[i].attributes[0].value !== "LoopEndBrick") {
-        i++;
         currentScript.brickList[position].loopOrIfBrickList.push(parseBrick(brickList[i]));
+        i++;
       }
-
-      console.log(currentScript.brickList[position].loopOrIfBrickList);
     }
     else {
       currentScript.brickList.push(parseBrick(brickList[i]));

--- a/src/js/parser/parser.js
+++ b/src/js/parser/parser.js
@@ -232,7 +232,19 @@ function parseScripts(script) {
   }
 
   for (let i = 0; i < brickList.length; i++) {
-    currentScript.brickList.push(parseBrick(brickList[i]));
+    if(brickList[i].attributes[0].value === "RepeatBrick") {
+      currentScript.brickList.push(parseBrick(brickList[i]));
+      const position = i;
+      while(brickList[i].attributes[0].value !== "LoopEndBrick") {
+        i++;
+        currentScript.brickList[position].loopOrIfBrickList.push(parseBrick(brickList[i]));
+      }
+
+      console.log(currentScript.brickList[position].loopOrIfBrickList);
+    }
+    else {
+      currentScript.brickList.push(parseBrick(brickList[i]));
+    }
   }
   return currentScript;
 }
@@ -509,7 +521,7 @@ export default class Parser {
 
   /**
 	 * Parse xmlString from catroid to catblocks format and return every error
-	 * @param {string|Element} xmlString catroid string or XMLDocument 
+	 * @param {string|Element} xmlString catroid string or XMLDocument
 	 * @returns {XMLDocument} catblock XMLDocument
 	 */
   static convertProgramStringDebug(xmlString) {
@@ -524,7 +536,7 @@ export default class Parser {
       } else if (appVersion[0].innerHTML < supportedAppVersion) {
         throw new Error(`Found program version ${appVersion[0].innerHTML}, minimum supported is ${supportedAppVersion}`);
       }
-      
+
       initParser(xml);
       return parseCatroidProgram(xml);
     }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -230,6 +230,23 @@ describe('Catroid to Catblocks parser tests', () => {
     })).toBeTruthy();
   });
 
+  /**
+   * Tests if parser adds the content of the repeat block, properly into the repeat block and not after the repeat block
+   */
+  test('Test to check, if the content in the repeat block is right', async () => {
+    expect(await page.evaluate(() => {
+      const xmlString = `<script type="StartScript"><brickList><brick type="PlaySoundBrick"><commentedOut>false</commentedOut></brick><brick type="RepeatBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIMES_TO_REPEAT"><type>NUMBER</type><value>1000000000</value></formula></formulaList></brick><brick type="SetBackgroundBrick"></brick><brick type="WaitBrick"></brick><brick type="LoopEndBrick"><commentedOut>false</commentedOut></brick></brickList><commentedOut>false</commentedOut><isUserScript>false</isUserScript></script>`;
+      const catXml = parser.convertScriptString(xmlString);
+      if (catXml.getElementsByTagName('parsererror').length > 0) return false;
+      return (catXml instanceof XMLDocument
+        && catXml.getElementsByTagName('block').length === 5
+        && catXml.getElementsByTagName('block')[2].getAttribute('type') === 'RepeatBrick'
+        && catXml.getElementsByTagName('block')[2].lastElementChild.children[0].getAttribute('type') === 'SetBackgroundBrick'
+        && catXml.getElementsByTagName('block')[2].lastElementChild.children[0].firstElementChild.children[0].getAttribute('type') === 'WaitBrick');
+    })).toBeTruthy();
+  });
+
+
   describe('UserVariable parsing', () => {
     /** 
      * Test if parser handles local uservariables properly


### PR DESCRIPTION
BLOCKS-60 
the bug was current parser version did not assign the bricks as child which are enclosed between the RepeatBrick and LoopEndBrick
and added it to the end of the RepeatBrick instead of into the RepeatBrick

added a for-loop which iterates through the content of the RepeatBrick and add it to his loopOrIfBricklist


### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
