### PR TITLE
BLOCKS-81 add github action workflow to use the gh-pages deploy action automatically on push [MF]

### DIFF
--- a/.github/workflows/action_deploy_developpage.yaml
+++ b/.github/workflows/action_deploy_developpage.yaml
@@ -1,0 +1,13 @@
+name: Deploy develop page to gh-pages
+
+on:
+  push:
+    branches: [ develop ] # merge creates commit + push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Project and push to gh-pages
+      uses: ./gh-pages-deploy-action/


### PR DESCRIPTION
Github Action to automatically start the deploy to gh-pages Action from ./gh-pages-deploy-action
With every merge of a pull request the newest version will be deployed to gh-pages.
https://jira.catrob.at/browse/BLOCKS-81

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
