### PR TITLE
BLOCKS-97 set display language in po-review docker 

### DIFF
--- a/docker/po-review/README.md
+++ b/docker/po-review/README.md
@@ -30,6 +30,10 @@ A combination of both is supported as well, but not separatly listed below.
 In case you have already built the `catblocks:po-review` container and you would like to reuse it. You can overwrite the
  entrypoint.sh file using the `-v /absolute/path/to/entrypoint.sh:/entrypoint.sh` option. Please validate that the 
  entrypoint.sh file is executable. 
+ 
+ 
+You can set the display language by adding following option `-e DISPLAY_LANGUAGE=de`. E.g. `de` for German. Without this option the blocks will be rendered with the default language.
+Use key values of locales from `i18n/lang_codes_mapping.js` to set display language.
 
 ## Single program testing
 For single program testing use the paramater method. 
@@ -42,6 +46,9 @@ Both values can be found on the [share](https://share.catrob.at/app/).
 
   # use program hash 
   docker run --rm -it -p 8080:8080 catblocks:po-review "4a20f223-5cbf-11ea-a2ae-000c292a0f49"
+
+  # use program hash and set display language to German
+  docker run --rm -it -e DISPLAY_LANGUAGE=de -p 8080:8080 catblocks:po-review "4a20f223-5cbf-11ea-a2ae-000c292a0f49" 
 ```
 
 This will download the program before launching the webserver.
@@ -67,4 +74,7 @@ can be done using the `-v` option.
 ```bash
  # mount folder and run bulk test
   docker run --rm -it -v ./catBulkTest:/test/programs/ -p 8080:8080 catblocks:po-review
+
+ # mount folder, set language to German and run bulk test
+  docker run --rm -it -e DISPLAY_LANGUAGE=de -v ./catBulkTest:/test/programs/ -p 8080:8080 catblocks:po-review
 ```

--- a/docker/po-review/entrypoint.sh
+++ b/docker/po-review/entrypoint.sh
@@ -54,7 +54,7 @@ echo "Extract all program archives"
 cd "${PROGROOT}"
 for FILE in $(ls * | grep -E '\.zip|\.catrobat')
 do
-  echo "Proces ${FILE} started"
+  echo "Process ${FILE} started"
   mkdir -p "${FILE%.*}/"
   unzip "$FILE" -d  "${FILE%.*}/"
   rm "$FILE"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -44,10 +44,22 @@ function initShareAndRenderPrograms(programPath) {
   const catblocksWorkspaceContainer = 'catblocks-workspace-container';
   const programContainer = document.getElementById('catblocks-programs-container');
   const share = new Share();
+  let language = 'en';
+  if (process.env.DISPLAY_LANGUAGE !== undefined && process.env.DISPLAY_LANGUAGE.length > 0) {
+    const values = Blockly.CatblocksMsgs.locales[process.env.DISPLAY_LANGUAGE];
+    if (values === undefined) {
+      console.warn('no language found for ' + process.env.DISPLAY_LANGUAGE + '. set to default.');
+      language = 'en';
+    }
+    else {
+      language = process.env.DISPLAY_LANGUAGE;
+    }
+  }
+  console.log("language: " + language);
   share.init({
     'container': catblocksWorkspaceContainer,
     'renderSize': 0.75,
-    'language': 'en',
+    'language': language,
     'shareRoot': '',
     'media': 'media/',
     'noImageFound': 'No_Image_Available.jpg',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,8 @@ module.exports = {
     ]),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development',
-      TYPE: 'catblocks'
+      TYPE: 'catblocks',
+      DISPLAY_LANGUAGE: process.env.DISPLAY_LANGUAGE ? process.env.DISPLAY_LANGUAGE : ""
     })
   ],
   // watch: true,


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-97

Changing display language in po-review docker is possible with environment variables now. When you set the environment variable with the -e flag on docker run, the display language of the blocks will be changed. If -e option is not set, then the default language is used. 
[See readme](https://github.com/georgsc/Catblocks/blob/BLOCKS-97/docker/po-review/README.md) 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
