### PR TITLE
BLOCKS-115 share is working again

### DIFF
--- a/src/html/share.html
+++ b/src/html/share.html
@@ -5,42 +5,31 @@
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <title>Catblocks Share</title>
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+          integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.15.0/css/mdb.min.css" rel="stylesheet">
 </head>
 
 <body>
-    <div id='catblocks-code-container'>
+    <div id="catblocks-workspace-container"></div>
+    <div id="catblocks-programs-container"></div>
+    <div id="loading-overlay">
+        <div class="loading-inner">
+            <div class="loader-icon"></div>
+        </div>
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+            integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+            crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+            integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+            crossorigin="anonymous"></script>
 </body>
-<script>
-    // share get exported by the bundle
-    share.init({
-        'container': 'catblocks-code-container',
-        'renderSize': 0.75,
-        'language': 'en',
-        'shareRoot': '/',
-        'media': 'media/',
-        'noImageFound': 'No_Image_Available.jpg',
-    });
-
-
-    // render my code.xml file
-    window.onload = function() {
-        share.parser.convertProgramUri(`assets/share/code.xml`)
-            .then(xmlDoc => {
-                console.log(xmlDoc);
-                const div = document.getElementById('catblocks-code-container');
-                share.injectAllScenes(div, xmlDoc, {
-                    object: {
-                        programRoot: 'assets/share/'
-                    }
-                });
-            })
-            .catch(err => {
-                console.error(`Failed to parse catroid file.`);
-                console.error(err);
-            });
-    };
-
-</script>
-
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -18,27 +18,13 @@ import { renderAllPrograms } from './render/render';
     break;
   }
   case 'share': {
-    window.share = new Share();
+    const programPath = 'assets/';
+    initShareAndRenderPrograms(programPath);
     break;
   }
   case 'render': {
-    const progPath = 'assets/programs/';
-    const catblocksWs = 'catblocks-workspace-container';
-    const progContainer = document.getElementById('catblocks-programs-container');
-
-    console.log(`Render every program which is located in ${progPath} directory`);
-    console.log(`If this page was loaded by your catblocks docker image, we copy first /test/programs/ to ${progPath}`);
-
-    const share = new Share();
-    share.init({
-      'container': catblocksWs,
-      'renderSize': 0.75,
-      'language': 'en',
-      'shareRoot': '',
-      'media': 'media/',
-      'noImageFound': 'No_Image_Available.jpg',
-    });
-    renderAllPrograms(share, progContainer, progPath);
+    const programPath = 'assets/programs/';
+    initShareAndRenderPrograms(programPath);
     break;
   }
   case 'testing': {
@@ -53,3 +39,18 @@ import { renderAllPrograms } from './render/render';
   }
   }
 })();
+
+function initShareAndRenderPrograms(programPath) {
+  const catblocksWorkspaceContainer = 'catblocks-workspace-container';
+  const programContainer = document.getElementById('catblocks-programs-container');
+  const share = new Share();
+  share.init({
+    'container': catblocksWorkspaceContainer,
+    'renderSize': 0.75,
+    'language': 'en',
+    'shareRoot': '',
+    'media': 'media/',
+    'noImageFound': 'No_Image_Available.jpg',
+  });
+  renderAllPrograms(share, programContainer, programPath);
+}


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-115

share:dev is working now with new material-icons design.
Copied `<link>`, `<div>` and `<script>` tags from render.html. Moved javascript code from share.html to index.js. 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer