### PR TITLE
BLOCKS-80: some programs can't be rendered anymore

### DIFF
--- a/src/js/parser/parser.js
+++ b/src/js/parser/parser.js
@@ -258,15 +258,15 @@ function parseScripts(script) {
 
   let positionInScriptBrickList = 0;
   for (let i = 0; i < brickList.length; i++) {
-    if (brickList[i].attributes[0].value === "RepeatBrick") {
+    if (brickList[i].attributes[0].value === "RepeatBrick" && checkIfNewProgram("RepeatBrick", brickList)) {
       const loopFinished = fillLoopControlBrick(brickList, currentScript, "RepeatBrick", i, positionInScriptBrickList, null,true);
       i = loopFinished + 1;
     }
-    else if(brickList[i].attributes[0].value === "IfThenLogicBeginBrick") {
+    else if(brickList[i].attributes[0].value === "IfThenLogicBeginBrick" && checkIfNewProgram("IfThenLogicBeginBrick", brickList)) {
       const ifFinished = fillLoopControlBrick(brickList, currentScript, "IfThenLogicBeginBrick", i, positionInScriptBrickList, null,true);
       i = ifFinished + 1;
     }
-    else if(brickList[i].attributes[0].value === "IfLogicBeginBrick") {
+    else if(brickList[i].attributes[0].value === "IfLogicBeginBrick" && checkIfNewProgram("IfLogicBeginBrick", brickList)) {
       const ifFinished = fillLoopControlBrick(brickList, currentScript, "IfLogicBeginBrick", i, positionInScriptBrickList, null,true);
       i = ifFinished + 1;
     }
@@ -276,7 +276,26 @@ function parseScripts(script) {
     }
   }
   return currentScript;
+}
 
+function checkIfNewProgram(currentBrick, brickList) {
+  let endBrick;
+  if(currentBrick === 'RepeatBrick') {
+    endBrick = "LoopEndBrick";
+  }
+  else if(currentBrick === 'IfLogicBeginBrick') {
+    endBrick = "IfLogicEndBrick";
+  }
+  else if(currentBrick === 'IfThenLogicBeginBrick') {
+    endBrick = "IfThenLogicEndBrick";
+  }
+
+  for(let i = 0; i < brickList.length; i++) {
+    if(brickList[i].attributes[0].value === endBrick) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function fillLoopControlBrick(brickList, currentScript, currentBrick, counter, positionInScriptBrickList, currentListToFill = null ,firstCall = false) {
@@ -299,6 +318,7 @@ function fillLoopControlBrick(brickList, currentScript, currentBrick, counter, p
   if(firstCall){
     currentScript.brickList.push(parseBrick(brickList[i]));
   }
+
   positionInScriptBrickList++;
   let position = 0;
   if(positionInScriptBrickList !== 0) {


### PR DESCRIPTION
Fixed the bug where some programs couldn't be rendered anymore in the share page

The problem was, that some ifBricks/IfElseBricks/RepeatBricks didn't fill their lists properly with bricks, so those programs couldn't be rendered anymore
I added this functionality now in the parser and the bricks get rendered properly again.


### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
