### PR TITLE
BLOCKS-119 implement release module and webpack config [MF]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ i18n/json
 \.vscode/
 ./jenkins/testresults/*
 jest_html_reporters.html
+release/

--- a/i18n/create_msg.js
+++ b/i18n/create_msg.js
@@ -10,6 +10,7 @@
  *            2019-09-06: changed logic to generate just one catblocks_msgs.js file
  *            2019-11-05: [MF] updated to new structure
  *            2020-04-09: [GS] added loadNewLocale() for lazy language loading
+ *            2020-05-14: [MF] add filesLocation for i18n
  */
 
 const fs = require('fs');
@@ -44,10 +45,10 @@ Blockly.CatblocksMsgs.hasLocale = function(locale) {
   return Object.keys(Blockly.CatblocksMsgs.locales).includes(locale);
 };
 
-Blockly.CatblocksMsgs.setLocale = function(locale) {
+Blockly.CatblocksMsgs.setLocale = function(locale, filesLocation = undefined) {
   if (Blockly.CatblocksMsgs.hasLocale(locale)) {
     if (Object.keys(Blockly.CatblocksMsgs.locales[locale]).length === 1) {
-      return Blockly.CatblocksMsgs.loadNewLocale(locale).then(() => {
+      return Blockly.CatblocksMsgs.loadNewLocale(locale, filesLocation).then(() => {
         Blockly.CatblocksMsgs.currentLocale_ = locale;
         Blockly.Msg = Object.assign({}, Blockly.Msg, Blockly.CatblocksMsgs.locales[locale]);
       });
@@ -74,9 +75,22 @@ Blockly.CatblocksMsgs.getCurrentLocaleValues = function() {
   return Blockly.CatblocksMsgs.locales[Blockly.CatblocksMsgs.getCurrentLocale()];
 };
 
-Blockly.CatblocksMsgs.loadNewLocale = function(locale) {
+Blockly.CatblocksMsgs.loadNewLocale = function(locale, filesLocation) {
   let json_object = [];
-  const url = window.location.protocol + "//" + window.location.host + "/i18n/" + locale + ".json";
+  let url = window.location.protocol + "//" + window.location.host + "/i18n/" + locale + ".json";
+
+  if (filesLocation != null) {
+    if (filesLocation.startsWith("http")) {
+      url = filesLocation.replace(/\\/$/, "");
+      url += "/" + locale + ".json";
+
+    } else {
+      url = filesLocation.replace(/\\/$/, "") + "/" + locale + ".json";
+      url = url.replace(/^\\//, "");
+      url = window.location.protocol + "//" + window.location.host + "/" + url;
+    }
+  }
+
   return $.getJSON(url, function (result) {
     json_object = result;
     Object.keys(json_object).forEach(key => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:dev": "cross-env-shell NODE_ENV=development TYPE=testing \"yarn initiate && webpack-dev-server\"",
     "initiate": "yarn translate",
     "translate": "node i18n/create_json.js && node i18n/create_msg.js",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ; rimraf release",
+    "release": "yarn initiate && webpack --config release.config.js"
   },
   "dependencies": {
     "@babel/core": "^7.6.4",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  mode: 'development',
+  entry: path.join(__dirname, 'src/js/release.js'),
+  output: {
+    filename: 'CatBlocks.js',
+    path: path.resolve(__dirname, 'release'),
+    libraryTarget: 'var',
+    library: 'CatBlocks'
+  },
+  resolve: {
+    extensions: ['.js', '.json']
+  },
+  module: {
+    rules: [
+      {
+        enforce: 'pre',
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'eslint-loader',
+        options: {
+          fix: true
+        }
+      },
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          'css-loader',
+          // 'postcss-loader',
+          // 'sass-loader'
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.join(__dirname, 'src/html/release.html'),
+      filename: 'index.html',
+      hash: true
+    }),
+    new MiniCssExtractPlugin({
+      // Options similar to the same options in webpackOptions.output
+      // all options are optional
+      filename:  '[name].css',
+      chunkFilename: '[id].css',
+      ignoreOrder: false, // Enable to remove warnings about conflicting order
+    }),
+    new CopyPlugin([
+      { from: 'assets', to: 'media' },
+      { from: 'node_modules/blockly/media', to: 'media' },
+      { from: 'i18n/json', to: 'i18n' },
+      { from: 'test/share', to: 'assets/share' },
+      { from: 'favicon.ico', to: 'favicon.ico' }
+    ])
+  ],
+  target: 'web',
+  devtool: 'source-map',
+};

--- a/src/html/release.html
+++ b/src/html/release.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Release Example</title>
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+        integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.15.0/css/mdb.min.css" rel="stylesheet">
+</head>
+
+<body>
+    <div id="catblocks-program-container"></div>
+    <script>
+        window.onload = function () {
+            CatBlocks.init({
+                container: "catblocks-program-container",
+                renderSize: 0.75,
+                language: 'de',
+                media: 'media',
+                i18n: 'i18n'
+            });
+
+            CatBlocks.render('assets', 'share')
+                .then(() => {
+                    console.log('success');
+                })
+                .catch((e) => {
+                    console.error(e);
+                });
+        }
+    </script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+        integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+        integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+        crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/src/js/catblocks_msgs.js
+++ b/src/js/catblocks_msgs.js
@@ -13,10 +13,10 @@ Blockly.CatblocksMsgs.hasLocale = function(locale) {
   return Object.keys(Blockly.CatblocksMsgs.locales).includes(locale);
 };
 
-Blockly.CatblocksMsgs.setLocale = function(locale) {
+Blockly.CatblocksMsgs.setLocale = function(locale, filesLocation = undefined) {
   if (Blockly.CatblocksMsgs.hasLocale(locale)) {
     if (Object.keys(Blockly.CatblocksMsgs.locales[locale]).length === 1) {
-      return Blockly.CatblocksMsgs.loadNewLocale(locale).then(() => {
+      return Blockly.CatblocksMsgs.loadNewLocale(locale, filesLocation).then(() => {
         Blockly.CatblocksMsgs.currentLocale_ = locale;
         Blockly.Msg = Object.assign({}, Blockly.Msg, Blockly.CatblocksMsgs.locales[locale]);
       });
@@ -43,9 +43,22 @@ Blockly.CatblocksMsgs.getCurrentLocaleValues = function() {
   return Blockly.CatblocksMsgs.locales[Blockly.CatblocksMsgs.getCurrentLocale()];
 };
 
-Blockly.CatblocksMsgs.loadNewLocale = function(locale) {
+Blockly.CatblocksMsgs.loadNewLocale = function(locale, filesLocation) {
   let json_object = [];
-  const url = window.location.protocol + "//" + window.location.host + "/i18n/" + locale + ".json";
+  let url = window.location.protocol + "//" + window.location.host + "/i18n/" + locale + ".json";
+
+  if (filesLocation != null) {
+    if (filesLocation.startsWith("http")) {
+      url = filesLocation.replace(/\/$/, "");
+      url += "/" + locale + ".json";
+
+    } else {
+      url = filesLocation.replace(/\/$/, "") + "/" + locale + ".json";
+      url = url.replace(/^\//, "");
+      url = window.location.protocol + "//" + window.location.host + "/" + url;
+    }
+  }
+
   return $.getJSON(url, function (result) {
     json_object = result;
     Object.keys(json_object).forEach(key => {

--- a/src/js/release.js
+++ b/src/js/release.js
@@ -1,0 +1,45 @@
+import "../css/share.css";
+import { Share } from "./share/share";
+import Blockly from "blockly";
+import { renderProgram } from "./render/render";
+import "./catblocks_msgs";
+import "./blocks";
+
+
+/**
+ * Initialize Share-Object and change Language
+ *
+ * @export
+ * @param {*} config
+ */
+export function init (config) {
+  this.config = config;
+  this.share = new Share();
+  this.share.init(config);
+
+  let language = 'en';
+  if (config.language != null) {
+    language = config.language;
+  }
+  Blockly.CatblocksMsgs.setLocale(language, config.i18n);
+}
+
+
+/**
+ * Render program from given path
+ *
+ * @export
+ * @param {*} path Path containing the program folders
+ * @param {*} name Name of program folder
+ * @returns Promise 
+ */
+export function render (path, name) {
+  if (this.config == null || this.config.container == null) {
+    throw new Error("No Container specified");
+  } else if (path == null) {
+    throw new Error("No path specified");
+  }
+
+  const programContainer = document.getElementById(this.config.container);
+  return renderProgram(this.share, programContainer, path, name);
+}

--- a/src/js/render/render.js
+++ b/src/js/render/render.js
@@ -51,7 +51,8 @@ export const renderAllPrograms = (share, container, path) => {
 };
 
 /**
- * Render a program from filesystem
+ * Render a program from filesystem, used on share.
+ * Does not catch any errors.
  * @param {Share} share instance of share
  * @param {Element} container parent container for structure
  * @param {string} path path of the folder containing the program
@@ -59,8 +60,14 @@ export const renderAllPrograms = (share, container, path) => {
  * @param {number} counter number added to ID to be unique
  * @returns {Promise} 
  */
-const renderProgram = (share, container, path, name, counter) => {
-  // inject code
+export const renderProgram = (share, container, path, name, counter = -1) => {
+  
+  // be sure that path has a trailing slash
+  path = path.replace(/\/$/, "") + "/";
+
+  // remove the leading slash
+  name = name.replace(/^\//, "");
+
   return fetch(`${path}${name}/code.xml`).then(res => res.text())
     .then(codeXML => {
       const xmlDoc = share.parser.convertProgramStringDebug(codeXML);
@@ -69,16 +76,16 @@ const renderProgram = (share, container, path, name, counter) => {
       // prepare container for program injection
       const programContainer = createProgramContainer(container);
 
-      const programID = `catblocks-program-${name}-${counter}`;
+      let programID = `catblocks-program-${name}`;
+      if (counter >= 0) {
+        programID = `catblocks-program-${name}-${counter}`;
+      }
+
       share.renderProgramJSON(programID, programContainer, programJSON, xmlDoc, {
         object: {
           programRoot: `${path}${name}/`
         }
       });
-    }).catch(err => {
-      console.error(`Failed to parse catroid file.`);
-      console.error(`${path}${name}/code.xml failed`);
-      console.error(err);
     });
 };
 
@@ -114,7 +121,7 @@ const renderProgramByLocalFile = (share, container, codeXML, name, counter, file
  */
 const createProgramContainer = (container) => {
   const $programContainer = $('<div/>', {
-    class: 'container text-dark'
+    class: 'catblocks-container text-dark'
   });
   $(container).append($programContainer);
   return $programContainer[0];

--- a/src/js/share/share.js
+++ b/src/js/share/share.js
@@ -156,6 +156,7 @@ export class Share {
       svg.setAttribute('class', 'catblocks-svg');
 
     } catch (e) {
+      console.error(e);
       console.error('Failed to generate SVG from workspace, properly due to unknown bricks');
       return undefined;
     }
@@ -603,12 +604,12 @@ export class Share {
    */
   createProgramContainer(containerID, container) {
     const row = injectNewDom(container, 'div', {
-      class: 'row mt-5',
+      class: 'row',
       id: containerID
     });
 
     const col = injectNewDom(row, 'div', {
-      class: 'col-12'
+      style: 'width: 100%'
     });
 
     return col;


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-119

Implemented webpack config `release.config.js`, which uses entrypoint `src/release.js`. It exports a CatBlocks-Object with functions `init` and `render`. Also removed some CSS classes, to not destroy the layout on Share.

To build the release use `yarn release`. The packaged Library is located in the release folder.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
