### PR TITLE
BLOCKS-84 Support Unsupported Bricks [BP]

### DIFF
--- a/.github/workflows/interval_brickcheck_action.yaml
+++ b/.github/workflows/interval_brickcheck_action.yaml
@@ -1,0 +1,18 @@
+name: Interval Action for Brick Support Check
+
+on:
+    schedule:
+        - cron: '0 7 * * 1' # Mondays 7AM UTC
+
+jobs:
+    runDocker:
+        if: github.repository == 'Catrobat/Catblocks'
+        name: checkout repo and check supported bricks
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout repo
+              uses: actions/checkout@v2
+            - name: run checker for brick support
+              uses: ./brick-support-checker-action/
+              with:
+                slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/brick-support-checker-action/Dockerfile
+++ b/brick-support-checker-action/Dockerfile
@@ -1,0 +1,41 @@
+FROM alpine
+
+MAINTAINER Catblocks "https://github.com/Catrobat/Catblocks"
+
+ARG CATBLOCKSREPO="https://github.com/Catrobat/Catblocks.git"
+ARG CATROIDREPO="https://github.com/Catrobat/Catroid.git"
+ARG WORKDIR="/checker/"
+
+# enable new repositories
+RUN \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+# update and upgrade
+RUN apk --no-cache  update \
+  && apk --no-cache  upgrade
+
+# install build dependencies
+RUN apk add --no-cache --virtual .build-deps python3 py3-pip
+
+RUN apk add --no-cache --virtual udev git
+
+# install required python packages
+RUN pip3 install --upgrade pip
+RUN pip3 install requests
+
+# remove cache
+RUN rm -rf /var/cache/apk/* /tmp/*
+
+ENV CATBLOCKS=${CATBLOCKSREPO}
+ENV CATROID=${CATROIDREPO}
+ENV WORKDIR=${WORKDIR}
+
+# copy python script to docker
+COPY require/checker.py /checker.py
+
+# cmd
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/brick-support-checker-action/action.yml
+++ b/brick-support-checker-action/action.yml
@@ -1,0 +1,11 @@
+name: "Catroid Brick Support Checker Action"
+description: "Compares Catroid bricks with Catblocks bricks and sends the new bricks to Slack"
+inputs:
+    slack_webhook:
+      description: 'Webhook to post on in #catblocks Slack channel'
+      required: true
+runs:
+    using: 'docker'
+    image: 'Dockerfile'
+    args: 
+        - ${{ inputs.slack_webhook }}

--- a/brick-support-checker-action/entrypoint.sh
+++ b/brick-support-checker-action/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+: '
+Catrobat Brick Support Checker Action
+'
+
+# Create directory where the Catroid and Catblocks projects should be cloned to
+mkdir $WORKDIR && cd $WORKDIR
+
+git clone $CATBLOCKS
+git clone $CATROID
+
+# copy the json-files to the working directory
+cp -r Catblocks/src/js/blocks/categories categories
+
+# run checker & send report
+python3 /checker.py "$WORKDIR" "$1"

--- a/brick-support-checker-action/require/checker.py
+++ b/brick-support-checker-action/require/checker.py
@@ -1,0 +1,136 @@
+# This script automatically compares supported Catroid and Catblocks bricks and sends the report with a given slack webhook.
+# Required Parameters: Working Directory of Catblocks & Catroid Project and a Slack Webhook.
+
+import json
+import os
+import sys
+import requests
+
+# if some files should be excluded for the checks, add them here
+excluded_js_files = ['index.js']
+excluded_java_files = ['Brick.java', 'BrickBaseType.java', 'BroadcastMessageBrick.java', 'CompositeBrick.java', 'ScriptBrick.java',
+  'UserVariableBrickInterface.java', 'BrickSpinner.java', 'FormulaBrick.java', 'ScriptBrickBaseType.java', 'UserListBrick.java',
+  'UserVariableBrick.java', 'UserVariableBrickWithFormula.java', 'VisualPlacementBrick.java']
+excluded_js_bricks = ['WhenClonedScript', 'StartScript', 'WhenScript', 'WhenTouchDownScript', 'BroadcastScript', 'WhenConditionScript',
+  'WhenBounceOffScript', 'WhenBackgroundChangesScript']
+
+
+# Loads the bricks supported by Catblocks from the JSON data.
+def loadCatblocksBricks(base_dir):
+  path = base_dir + '/categories/'
+  files = os.listdir(path)
+
+  js_bricks = []
+
+  for filename in files:
+    if filename in excluded_js_files:
+      continue
+
+    filename = path + filename
+    f = open(filename, 'r')
+    content = f.read()
+    json_str = content[content.find('{'):content.rfind(';')].replace('`', '"')
+    #print(json_str)
+    parsed_json = json.loads(json_str)
+
+    for brick_name in parsed_json:
+      if brick_name in excluded_js_bricks:
+        continue
+      
+      js_bricks.append(brick_name)
+  
+  return js_bricks
+
+
+# Loads the bricks supported by Catroid by searching in the bricks-folder of Catroid.
+# Each .java-file is one brick.
+def loadCatroidBricks(base_dir):
+  path = base_dir + '/Catroid/catroid/src/main/java/org/catrobat/catroid/content/bricks/'
+  files = os.listdir(path)
+  
+  java_bricks = []
+
+  for filename in files:
+    if not filename.endswith('.java') or filename in excluded_java_files:
+      continue
+    java_bricks.append(filename.replace('.java', ''))
+
+  return java_bricks
+
+
+# Compares the two arrays
+def compareBricks(java_bricks, js_bricks):
+  in_js_not_java = []
+  in_java_not_js = []
+
+  for java_brick in java_bricks:
+    if java_brick not in js_bricks:
+      in_java_not_js.append(java_brick)
+  
+  for js_brick in js_bricks:
+    if js_brick not in java_bricks:
+      in_js_not_java.append(js_brick)
+
+  return in_java_not_js, in_js_not_java
+
+
+# Builds the report for the missing bricks
+def generateSlackMessage(missing_bricks, categories):
+  msg = '*Missing Bricks in Catblocks*:\n'
+  for brick in missing_bricks:
+    category = getCategoryForJavaBrick(brick, categories)
+    if category is not None:
+      msg += brick + ' [' + category + ']\n'
+    else:
+      msg += brick + '\n'
+  return msg.strip()
+    
+
+# Loads the .java-file where bricks are but in categories.
+# First the import-statements are removed
+def loadJavaCategoryClass(base_dir):
+  path = base_dir + '/Catroid/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java'
+  f = open(path, 'r')
+  content = f.read()
+  content = content[content.find("public class"):]
+  return content
+
+
+# Searches the CategoryBricksFactory for the line where the brick is put in the
+# category list
+def getCategoryForJavaBrick(blockname, category_class):
+  for line in category_class:
+    if blockname in line:
+      if '.add' in line:
+        try:
+          return line.split('.')[0].replace('List', '').strip()
+        except:
+          return None
+  return None
+
+
+def sendSlackMessage(webhook, message):
+  json_data = { 'text': message }
+  requests.post(webhook, json=json_data)
+
+
+# Requires the following Args: 
+#   [1] Path to the parent folder of Catblocks & Catroid project
+#   [2] Slack Webhook URL
+def main():
+  path = sys.argv[1]
+  slack_webhook = sys.argv[2]
+
+  java_bricks = loadCatroidBricks(path)
+  js_bricks = loadCatblocksBricks(path)
+
+  in_java_not_js, in_js_not_java = compareBricks(java_bricks, js_bricks)
+
+  if in_java_not_js is not None and len(in_java_not_js) > 0:
+    category_class = loadJavaCategoryClass(path).splitlines()
+    slack_msg = generateSlackMessage(in_java_not_js, category_class)
+    sendSlackMessage(slack_webhook, slack_msg)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
A docker pulls the Catroid and Catblocks projects and compares the supported bricks using a python script. If there are unsupported bricks in Catblocks, a report is sent to Slack.
https://jira.catrob.at/browse/BLOCKS-84

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
