### PR TITLE
BLOCKS-111 Render SVG Blocks without XML

### DIFF
--- a/src/html/playground.html
+++ b/src/html/playground.html
@@ -39,7 +39,7 @@
     <p>
       <input type="button" id="exportToXML" value="Export to XML" />
       &nbsp;
-      <input type="button" id="importFromXML" value="Import from XML" />
+      <input type="button" id="importFromJSON" value="Import from JSON" />
       &nbsp;
       <input type="button" id="importFromParser" value="Import using Parser" />
       <br />

--- a/src/js/render/render.js
+++ b/src/js/render/render.js
@@ -109,7 +109,6 @@ export const renderProgram = (share, container, path, name, counter = -1) => {
   return fetch(`${path}${name}/code.xml`)
     .then(res => res.text())
     .then(codeXML => {
-      const xmlDoc = share.parser.convertProgramStringDebug(codeXML);
       const programJSON = share.parser.convertProgramToJSONDebug(codeXML);
 
       // prepare container for program injection
@@ -120,7 +119,7 @@ export const renderProgram = (share, container, path, name, counter = -1) => {
         programID = `catblocks-program-${name}-${counter}`;
       }
 
-      share.renderProgramJSON(programID, programContainer, programJSON, xmlDoc, {
+      share.renderProgramJSON(programID, programContainer, programJSON, {
         object: {
           programRoot: `${path}${name}/`
         }
@@ -139,14 +138,13 @@ export const renderProgram = (share, container, path, name, counter = -1) => {
  */
 const renderProgramByLocalFile = (share, container, codeXML, name, counter, fileMap) => {
   // inject code
-  const xmlDoc = share.parser.convertProgramStringDebug(codeXML);
   const programJSON = share.parser.convertProgramToJSONDebug(codeXML);
 
   // prepare container for program injection
   const programContainer = createProgramContainer(container);
 
   const programID = `catblocks-program-${name}-${counter}`;
-  share.renderProgramJSON(programID, programContainer, programJSON, xmlDoc, {
+  share.renderProgramJSON(programID, programContainer, programJSON, {
     object: {
       fileMap: fileMap
     }

--- a/src/js/share/utils.js
+++ b/src/js/share/utils.js
@@ -283,11 +283,9 @@ export const renderAndConnectBlocksInList = (parentBlock, brickList, brickListTy
     childBlock.render(false);
     if (brickListType === brickListTypes.brickList) {
       parentBlock.nextConnection.connect(childBlock.previousConnection);
-    }
-    if (brickListType === brickListTypes.elseBrickList) {
+    } else if (brickListType === brickListTypes.elseBrickList) {
       parentBlock.inputList[3].connection.connect(childBlock.previousConnection);
-    }
-    if (brickListType === brickListTypes.loopOrIfBrickList) {
+    } else if (brickListType === brickListTypes.loopOrIfBrickList) {
       parentBlock.inputList[1].connection.connect(childBlock.previousConnection);
     }
     if (brickList[i].brickList !== undefined && brickList[i].brickList.length > 0) {

--- a/src/js/share/utils.js
+++ b/src/js/share/utils.js
@@ -6,6 +6,17 @@
 import md5 from 'js-md5';
 
 /**
+ * all list types in json object
+ * @enum {object}
+ */
+export const brickListTypes = Object.freeze({
+  noBrickList: 0,
+  brickList: 1,
+  elseBrickList: 2,
+  loopOrIfBrickList: 3
+});
+
+/**
  * Default options defined here
  * @enum {object}
  */
@@ -42,39 +53,6 @@ export const defaultOptions = {
  */
 export const parseOptions = (inputValues, defaultValues) => {
   return Object.assign({}, defaultValues, inputValues);
-};
-
-/**
- * Transform dom xml, execute actions define in options
- *  example value for tagActions parameter
- *  {
- *    'block': ['remAttr-id', 'remAttr-x', 'remAttr-y'],
- *    'shadow': ['remAttr-id', 'remAttr-x', 'remAttr-y']
- *   }
- *  this will remove the attributes [id, x, y] from all block and shadow nodes
- * @param {XMLDocument} xmlDom to transform
- * @param {object} tagActions to map against tag elements
- */
-export const transformXml = (xmlDom, tagActions) => {
-  Object.keys(tagActions).forEach(tagName => {
-    xmlDom.getElementsByTagName(tagName).forEach(node => {
-      tagActions[tagName].forEach(action => {
-        const actionType = action.split('-')[0];
-        const actionValue = action.split('-')[1];
-
-        // INFO: please add new features as needed
-        switch (actionType) {
-          case 'remAttr': {
-            node.removeAttribute(actionValue);
-            break;
-          }
-          default: {
-            console.warn('Ignore undefined XML transformation.');
-          }
-        }
-      });
-    });
-  });
 };
 
 /**
@@ -264,4 +242,72 @@ export const generateID = string => {
  */
 export const escapeURI = string => {
   return encodeURI(string).replace('#', '%23');
+};
+
+/**
+ * render json object to workspace
+ * @param {object} jsonObject current scriptList as object
+ * @param {object} workspace where blocks are rendered
+ */
+export const jsonDomToWorkspace = (jsonObject, workspace) => {
+  const blockList = [];
+  blockList.push(jsonObject);
+  renderAndConnectBlocksInList(null, blockList, brickListTypes.noBrickList, workspace);
+};
+
+/**
+ * Renders and connects all blocks in a brickList, elseBrickList and loopOrIfBrickList.
+ * Function is calling itself if a *brickList is in a *brickList.
+ * @param {Object} parentBlock parent block to connect
+ * @param {Object} brickList, elseBrickList or loopOrIfBrickList
+ * @param {object} brickListType of list
+ * @param {object} workspace where blocks are rendered
+ */
+export const renderAndConnectBlocksInList = (parentBlock, brickList, brickListType, workspace) => {
+  for (let i = 0; i < brickList.length; i++) {
+    const childBlock = workspace.newBlock(brickList[i].name);
+    if (
+      brickList[i].formValues !== undefined &&
+      brickList[i].formValues.size !== undefined &&
+      brickList[i].formValues.size > 0
+    ) {
+      brickList[i].formValues.forEach(function (value, key) {
+        for (let j = 0; j < childBlock.inputList[0].fieldRow.length; j++) {
+          if (childBlock.inputList[0].fieldRow[j].name === key) {
+            childBlock.inputList[0].fieldRow[j].setValue(value);
+          }
+        }
+      });
+    }
+    childBlock.initSvg();
+    childBlock.render(false);
+    if (brickListType === brickListTypes.brickList) {
+      parentBlock.nextConnection.connect(childBlock.previousConnection);
+    }
+    if (brickListType === brickListTypes.elseBrickList) {
+      parentBlock.inputList[3].connection.connect(childBlock.previousConnection);
+    }
+    if (brickListType === brickListTypes.loopOrIfBrickList) {
+      parentBlock.inputList[1].connection.connect(childBlock.previousConnection);
+    }
+    if (brickList[i].brickList !== undefined && brickList[i].brickList.length > 0) {
+      renderAndConnectBlocksInList(childBlock, brickList[i].brickList.reverse(), brickListTypes.brickList, workspace);
+    }
+    if (brickList[i].elseBrickList !== undefined && brickList[i].elseBrickList.length > 0) {
+      renderAndConnectBlocksInList(
+        childBlock,
+        brickList[i].elseBrickList.reverse(),
+        brickListTypes.elseBrickList,
+        workspace
+      );
+    }
+    if (brickList[i].loopOrIfBrickList !== undefined && brickList[i].loopOrIfBrickList.length > 0) {
+      renderAndConnectBlocksInList(
+        childBlock,
+        brickList[i].loopOrIfBrickList.reverse(),
+        brickListTypes.loopOrIfBrickList,
+        workspace
+      );
+    }
+  }
 };

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -14,10 +14,15 @@ describe('Parser catroid program tests', () => {
   test('Recognizes not supported program version', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.993</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        return catXml === undefined;
+        try {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.993</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
+          parser.convertProgramToJSONDebug(xmlString);
+        } catch (e) {
+          if (e.message === 'Found program version 0.993, minimum supported is 0.994') {
+            return true;
+          }
+        }
+        return false;
       })
     ).toBeTruthy();
   });
@@ -26,9 +31,13 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.994</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        return catXml instanceof XMLDocument;
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        return (
+          programJSON !== undefined &&
+          programJSON.scenes !== undefined &&
+          programJSON.scenes[0].name !== undefined &&
+          programJSON.scenes[0].objectList !== undefined
+        );
       })
     ).toBeTruthy();
   });
@@ -37,13 +46,11 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.994</catrobatLanguageVersion></header><scenes></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.firstChild.childElementCount === 0
-        );
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
+        return programJSON.scenes !== undefined;
       })
     ).toBeTruthy();
   });
@@ -52,13 +59,15 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.994</catrobatLanguageVersion></header><scenes><scene><name>tscene</name><objectList></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.getElementsByTagName('scene').length === 1 &&
-          catXml.getElementsByTagName('scene')[0].getAttribute('type') === 'tscene'
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 1 &&
+          programJSON.scenes[0].name === 'tscene' &&
+          programJSON.scenes[0].objectList !== undefined
         );
       })
     ).toBeTruthy();
@@ -68,72 +77,82 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.994</catrobatLanguageVersion></header><scenes><scene><name>tscene1</name><objectList></objectList></scene><scene><name>tscene2</name><objectList></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.getElementsByTagName('scene').length === 2 &&
-          catXml.getElementsByTagName('scene')[0].getAttribute('type') === 'tscene1' &&
-          catXml.getElementsByTagName('scene')[1].getAttribute('type') === 'tscene2'
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 2 &&
+          programJSON.scenes[0].name === 'tscene1' &&
+          programJSON.scenes[1].name === 'tscene2' &&
+          programJSON.scenes[0].objectList !== undefined &&
+          programJSON.scenes[1].objectList !== undefined
         );
       })
     ).toBeTruthy();
   });
 
-  test('Hanlde single empty object properly', async () => {
+  test('Handle single empty object properly', async () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.getElementsByTagName('object').length === 1 &&
-          catXml.getElementsByTagName('object')[0].getAttribute('type') === 'tobject'
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 1 &&
+          programJSON.scenes[0].name === 'tscene' &&
+          programJSON.scenes[0].objectList !== undefined &&
+          programJSON.scenes[0].objectList.length === 1 &&
+          programJSON.scenes[0].objectList[0].name === 'tobject'
         );
       })
     ).toBeTruthy();
   });
 
-  test('Hanlde single empty object in same scene properly', async () => {
+  test('Handle single empty object in same scene properly', async () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.getElementsByTagName('scene').length === 1 &&
-          catXml.getElementsByTagName('scene')[0].childElementCount === 2 &&
-          catXml.getElementsByTagName('object').length === 2 &&
-          catXml.getElementsByTagName('object')[0].getAttribute('type') === 'tobject1' &&
-          catXml.getElementsByTagName('object')[1].getAttribute('type') === 'tobject2'
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 1 &&
+          programJSON.scenes[0].name === 'tscene' &&
+          programJSON.scenes[0].objectList !== undefined &&
+          programJSON.scenes[0].objectList.length === 2 &&
+          programJSON.scenes[0].objectList[0].name === 'tobject1' &&
+          programJSON.scenes[0].objectList[1].name === 'tobject2'
         );
       })
     ).toBeTruthy();
   });
 
-  test('Hanlde single empty object in multiple scenes properly', async () => {
+  test('Handle single empty object in multiple scenes properly', async () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene1</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object></objectList></scene><scene><name>tscene2</name><objectList><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.firstChild.tagName === 'xml' &&
-          catXml.getElementsByTagName('scene').length === 2 &&
-          catXml.getElementsByTagName('scene')[0].getAttribute('type') === 'tscene1' &&
-          catXml.getElementsByTagName('scene')[1].getAttribute('type') === 'tscene2' &&
-          catXml.getElementsByTagName('scene')[0].childElementCount === 1 &&
-          catXml.getElementsByTagName('scene')[0].firstChild.getAttribute('type') === 'tobject1' &&
-          catXml.getElementsByTagName('scene')[0].firstChild.childElementCount === 0 &&
-          catXml.getElementsByTagName('scene')[1].childElementCount === 1 &&
-          catXml.getElementsByTagName('scene')[1].firstChild.getAttribute('type') === 'tobject2' &&
-          catXml.getElementsByTagName('scene')[1].firstChild.childElementCount === 0
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 2 &&
+          programJSON.scenes[0].name === 'tscene1' &&
+          programJSON.scenes[1].name === 'tscene2' &&
+          programJSON.scenes[0].objectList !== undefined &&
+          programJSON.scenes[1].objectList !== undefined &&
+          programJSON.scenes[0].objectList.length === 1 &&
+          programJSON.scenes[1].objectList.length === 1 &&
+          programJSON.scenes[0].objectList[0].name === 'tobject1' &&
+          programJSON.scenes[1].objectList[0].name === 'tobject2'
         );
       })
     ).toBeTruthy();
@@ -143,17 +162,21 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList/></script></scriptList></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        return catXml
-          .evaluate(
-            `//scene[@type='tscene']/object[@type='tobject']/script[@type='tscript']`,
-            catXml,
-            null,
-            XPathResult.ANY_TYPE,
-            null
-          )
-          .iterateNext();
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
+        return (
+          programJSON.scenes !== undefined &&
+          programJSON.scenes.length === 1 &&
+          programJSON.scenes[0].name === 'tscene' &&
+          programJSON.scenes[0].objectList !== undefined &&
+          programJSON.scenes[0].objectList.length === 1 &&
+          programJSON.scenes[0].objectList[0].name === 'tobject' &&
+          programJSON.scenes[0].objectList[0].scriptList !== undefined &&
+          programJSON.scenes[0].objectList[0].scriptList.length === 1 &&
+          programJSON.scenes[0].objectList[0].scriptList[0].name === 'tscript'
+        );
       })
     ).toBeTruthy();
   });
@@ -168,15 +191,12 @@ describe('Catroid to Catblocks parser tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="цель"><lookList><look fileName="Space-Panda.png" name="цель"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSizeToBrick" id="testBrick"><commentedOut>false</commentedOut><formulaList><formula category="SIZE"><type>NUMBER</type><value id="testValue">60&amp;.0</value></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        if (catXml.getElementsByTagName('parsererror').length > 0) {
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
           return false;
         }
-        const testValue = catXml
-          .evaluate(`//field[@name='SIZE']`, catXml, null, XPathResult.ANY_TYPE, null)
-          .iterateNext();
-        return testValue !== undefined && testValue.innerHTML.includes('60&amp;.0');
+        const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+        return formulaMap !== undefined && formulaMap.entries().next().value.toString().includes('60&.0');
       })
     ).toBeTruthy();
   });
@@ -185,32 +205,30 @@ describe('Catroid to Catblocks parser tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestLookListObject"><lookList><look fileName="testLook.png" name="testLook"/></lookList><soundList/><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetLookBrick"><commentedOut>false</commentedOut><look reference="../../../../../../object[1]/lookList/look[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        if (catXml.getElementsByTagName('parsererror').length > 0) {
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
           return false;
         }
-        const testValue = catXml
-          .evaluate(`//field[@name='look']`, catXml, null, XPathResult.ANY_TYPE, null)
-          .iterateNext();
-        return testValue !== undefined && testValue.innerHTML.includes('testLook');
+        const objectName = programJSON.scenes[0].objectList[0].name;
+        const lookName = programJSON.scenes[0].objectList[0].lookList[0].name;
+        const lookFileName = programJSON.scenes[0].objectList[0].lookList[0].fileName;
+        return objectName === 'TestLookListObject' && lookName === 'testLook' && lookFileName === 'testLook.png';
       })
     ).toBeTruthy();
   });
 
-  test('SountList reference not within the same object', async () => {
+  test('SoundList reference not within the same object', async () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList></lookList><soundList><sound fileName="testSound.png" name="testSound"/></soundList><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSoundBrick"><commentedOut>false</commentedOut><sound reference="../../../../../../object[1]/soundList/sound[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        if (catXml.getElementsByTagName('parsererror').length > 0) {
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
           return false;
         }
-        const testValue = catXml
-          .evaluate(`//field[@name='sound']`, catXml, null, XPathResult.ANY_TYPE, null)
-          .iterateNext();
-        return testValue !== undefined && testValue.innerHTML.includes('testSound');
+        const objectName = programJSON.scenes[0].objectList[0].name;
+        const soundName = programJSON.scenes[0].objectList[0].soundList[0].name;
+        const soundFileName = programJSON.scenes[0].objectList[0].soundList[0].fileName;
+        return objectName === 'TestSoundListObject' && soundName === 'testSound' && soundFileName === 'testSound.png';
       })
     ).toBeTruthy();
   });
@@ -219,15 +237,13 @@ describe('Catroid to Catblocks parser tests', () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList /><soundList><sound fileName="testSound.png" name="testSound" /></soundList><scriptList /></object><object type="Sprite" name="цель"><lookList /><soundList /><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="testFormular"><leftChild><type>NUMBER</type><value>37</value></leftChild><rightChild><type>NUMBER</type><value>58</value></rightChild><type>FUNCTION</type><value /></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
-        const catXml = parser.convertProgramString(xmlString);
-
-        if (catXml.getElementsByTagName('parsererror').length > 0) {
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
           return false;
         }
-        const testValue = catXml
-          .evaluate(`//field[@name='testFormular']`, catXml, null, XPathResult.ANY_TYPE, null)
-          .iterateNext();
-        return testValue !== undefined && testValue.innerHTML.includes('37 --- 58');
+        const brickName = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].name;
+        const formulaMap = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].formValues;
+        return brickName === 'WaitBrick' && formulaMap.entries().next().value.toString().includes('37 --- 58');
       })
     ).toBeTruthy();
   });
@@ -235,14 +251,16 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Test if parser converts catroid script properly', async () => {
     expect(
       await page.evaluate(() => {
-        const scriptString = `<script type="BroadcastScript"><brickList><brick type="ForeverBrick"><commentedOut>false</commentedOut><loopBricks><brick type="PlaySoundAndWaitBrick"><commentedOut>false</commentedOut><sound name="soundTest"/></brick></loopBricks></brick></brickList><commentedOut>false</commentedOut><receivedMessage>звуки</receivedMessage></script>`;
-        const catXml = parser.convertScriptString(scriptString);
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="BroadcastScript"><brickList><brick type="ForeverBrick"><commentedOut>false</commentedOut><loopBricks><brick type="PlaySoundAndWaitBrick"><commentedOut>false</commentedOut><sound name="soundTest"/></brick></loopBricks></brick></brickList><commentedOut>false</commentedOut><receivedMessage>звуки</receivedMessage></script></scriptList></object></objectList></scene></scenes></program>`;
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
+          return false;
+        }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.getElementsByTagName('block').length === 3 &&
-          catXml.getElementsByTagName('block')[0].getAttribute('type') === 'BroadcastScript' &&
-          catXml.getElementsByTagName('block')[1].getAttribute('type') === 'ForeverBrick' &&
-          catXml.getElementsByTagName('block')[2].getAttribute('type') === 'PlaySoundAndWaitBrick'
+          programJSON.scenes[0].objectList[0].scriptList[0].name === 'BroadcastScript' &&
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name === 'ForeverBrick' &&
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].loopOrIfBrickList[0].name ===
+            'PlaySoundAndWaitBrick'
         );
       })
     ).toBeTruthy();
@@ -251,20 +269,17 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Test to check, if the content in the repeat block is right', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<script type="StartScript"><brickList><brick type="PlaySoundBrick"><commentedOut>false</commentedOut></brick><brick type="RepeatBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIMES_TO_REPEAT"><type>NUMBER</type><value>1000000000</value></formula></formulaList></brick><brick type="SetBackgroundBrick"></brick><brick type="WaitBrick"></brick><brick type="LoopEndBrick"><commentedOut>false</commentedOut></brick></brickList><commentedOut>false</commentedOut><isUserScript>false</isUserScript></script>`;
-        const catXml = parser.convertScriptString(xmlString);
-        if (catXml.getElementsByTagName('parsererror').length > 0) {
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="PlaySoundBrick"><commentedOut>false</commentedOut></brick><brick type="RepeatBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIMES_TO_REPEAT"><type>NUMBER</type><value>1000000000</value></formula></formulaList></brick><brick type="SetBackgroundBrick"></brick><brick type="WaitBrick"></brick><brick type="LoopEndBrick"><commentedOut>false</commentedOut></brick></brickList><commentedOut>false</commentedOut><isUserScript>false</isUserScript></script></scriptList></object></objectList></scene></scenes></program>`;
+        const programJSON = parser.convertProgramToJSONDebug(xmlString);
+        if (programJSON === undefined) {
           return false;
         }
         return (
-          catXml instanceof XMLDocument &&
-          catXml.getElementsByTagName('block').length === 5 &&
-          catXml.getElementsByTagName('block')[2].getAttribute('type') === 'RepeatBrick' &&
-          catXml.getElementsByTagName('block')[2].lastElementChild.children[0].getAttribute('type') ===
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name === 'PlaySoundBrick' &&
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[1].name === 'RepeatBrick' &&
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[1].loopOrIfBrickList[0].name ===
             'SetBackgroundBrick' &&
-          catXml
-            .getElementsByTagName('block')[2]
-            .lastElementChild.children[0].firstElementChild.children[0].getAttribute('type') === 'WaitBrick'
+          programJSON.scenes[0].objectList[0].scriptList[0].brickList[1].loopOrIfBrickList[1].name === 'WaitBrick'
         );
       })
     ).toBeTruthy();
@@ -275,18 +290,16 @@ describe('Catroid to Catblocks parser tests', () => {
       expect(
         await page.evaluate(() => {
           const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>ARDRONE_LED_ANIMATION_BLINK_GREEN_RED</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
-          const catXml = parser.convertProgramString(xmlString);
-          const blockValue = catXml
-            .evaluate(
-              `//scene[@type='tscene']/object[@type='tobject']/script[@type='tscript']//block[@type='DronePlayLedAnimationBrick']/field[@name='ADRONEANIMATION']`,
-              catXml,
-              null,
-              XPathResult.ANY_TYPE,
-              null
-            )
-            .iterateNext();
-
-          return blockValue !== undefined && blockValue.innerHTML === 'Blink green red';
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          return (
+            programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name === 'DronePlayLedAnimationBrick' &&
+            formulaMap.size === 1 &&
+            formulaMap.entries().next().value.toString().includes('Blink green red')
+          );
         })
       ).toBeTruthy();
     });
@@ -295,18 +308,16 @@ describe('Catroid to Catblocks parser tests', () => {
       expect(
         await page.evaluate(() => {
           const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>SOME_VALUE_I_DO_NOT_CARE</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
-          const catXml = parser.convertProgramString(xmlString);
-          const blockValue = catXml
-            .evaluate(
-              `//scene[@type='tscene']/object[@type='tobject']/script[@type='tscript']//block[@type='DronePlayLedAnimationBrick']/field[@name='ADRONEANIMATION']`,
-              catXml,
-              null,
-              XPathResult.ANY_TYPE,
-              null
-            )
-            .iterateNext();
-
-          return blockValue !== undefined && blockValue.innerHTML === 'SOME_VALUE_I_DO_NOT_CARE';
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          return (
+            programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name === 'DronePlayLedAnimationBrick' &&
+            formulaMap.size === 1 &&
+            formulaMap.entries().next().value.toString().includes('SOME_VALUE_I_DO_NOT_CARE')
+          );
         })
       ).toBeTruthy();
     });
@@ -315,18 +326,15 @@ describe('Catroid to Catblocks parser tests', () => {
       expect(
         await page.evaluate(() => {
           const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
-          const catXml = parser.convertProgramString(xmlString);
-          const blockValue = catXml
-            .evaluate(
-              `//scene[@type='tscene']/object[@type='tobject']/script[@type='tscript']//block[@type='DronePlayLedAnimationBrick']`,
-              catXml,
-              null,
-              XPathResult.ANY_TYPE,
-              null
-            )
-            .iterateNext();
-
-          return blockValue !== undefined && blockValue.childElementCount === 0;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          return (
+            programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name === 'DronePlayLedAnimationBrick' &&
+            formulaMap.entries().next().value === undefined
+          );
         })
       ).toBeTruthy();
     });
@@ -336,16 +344,28 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.includes('tUserVariable');
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1] === 'tUserVariable' &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
@@ -353,16 +373,28 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local empty name uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.length === 0;
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1].length === 0 &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
@@ -370,16 +402,28 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local uservariable parsing without name tag', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.length === 0;
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1].length === 0 &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
@@ -387,16 +431,28 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.includes('tUserVariable');
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1] === 'tUserVariable' &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
@@ -404,16 +460,28 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote empty name uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.length === 0;
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1].length === 0 &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
@@ -421,80 +489,120 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote uservariable parsing without name tag', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='DROPDOWN']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          return testValue !== undefined && testValue.innerHTML.length === 0;
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const mapKeys = [];
+          const mapValues = [];
+          formulaMap.forEach(function (value, key) {
+            mapKeys.push(key);
+            mapValues.push(value);
+          });
+          return (
+            mapKeys.length === 2 &&
+            mapValues.length === 2 &&
+            mapKeys[0] === 'VARIABLE' &&
+            mapValues[0] === '0' &&
+            mapKeys[1] === 'DROPDOWN' &&
+            mapValues[1].length === 0 &&
+            block === 'SetVariableBrick'
+          );
         })
       ).toBeTruthy();
     });
 
-    test('Test if parser handels formular operator properly', async () => {
+    test('Test if parser handles formula operator properly', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="Y_POSITION"><leftChild><type>NUMBER</type><value>70</value></leftChild><rightChild><type>NUMBER</type><value>90</value></rightChild><type>OPERATOR</type><value>EQUAL</value></formula></formulaList></brick></script>`;
-          const catXml = parser.convertScriptString(xmlString);
-
-          if (catXml.getElementsByTagName('parsererror').length > 0) {
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="Y_POSITION"><leftChild><type>NUMBER</type><value>70</value></leftChild><rightChild><type>NUMBER</type><value>90</value></rightChild><type>OPERATOR</type><value>EQUAL</value></formula></formulaList></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
             return false;
           }
-          const testValue = catXml
-            .evaluate(`//field[@name='Y_POSITION']`, catXml, null, XPathResult.ANY_TYPE, null)
-            .iterateNext();
-          const refOperator = '=';
-          return testValue !== undefined && testValue.innerHTML.trim() === `70 ${refOperator} 90`;
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          return (
+            formulaMap.size === 1 &&
+            block === 'SetVariableBrick' &&
+            firstMapKey === 'Y_POSITION' &&
+            firstMapValue === '70 = 90'
+          );
         })
       ).toBeTruthy();
     });
   });
 
   describe('Formula brackets tests', () => {
-    test('Formular with right sided brackets', async () => {
+    test('Formula with right sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>9</value></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>DIVIDE</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>9</value></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>DIVIDE</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = '1 × (5 ÷ (9 + 8))'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('Formular with left sided brackets', async () => {
+    test('Formula with left sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>2</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>DIVIDE</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>2</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>DIVIDE</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = '((1 + 2) × 8) ÷ 8'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('Formular with both sided brackets', async () => {
+    test('Formula with both sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><type>NUMBER</type><value>6</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><type>NUMBER</type><value>6</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = '(1 × 5) + (5 × 6)'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
@@ -505,13 +613,21 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Single value like sqrt function with arithmetic', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>89</value></leftChild><type>FUNCTION</type><value>SQRT</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>89</value></leftChild><type>FUNCTION</type><value>SQRT</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = 'square root(89) × 5'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
@@ -520,13 +636,21 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Single value like sin function with logic', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>98</value></leftChild><type>FUNCTION</type><value>SIN</value></leftChild><rightChild><type>NUMBER</type><value>32</value></rightChild><type>OPERATOR</type><value>GREATER_THAN</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
-          const refString = 'sine(98) &gt; 32'.trim();
-
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>98</value></leftChild><type>FUNCTION</type><value>SIN</value></leftChild><rightChild><type>NUMBER</type><value>32</value></rightChild><type>OPERATOR</type><value>GREATER_THAN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
+          const refString = 'sine(98) > 32'.trim();
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
@@ -535,13 +659,21 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Two single values like sin plus cos', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>360</value></leftChild><type>FUNCTION</type><value>COS</value></leftChild><rightChild><leftChild><type>NUMBER</type><value>90</value></leftChild><type>FUNCTION</type><value>SIN</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>360</value></leftChild><type>FUNCTION</type><value>COS</value></leftChild><rightChild><leftChild><type>NUMBER</type><value>90</value></leftChild><type>FUNCTION</type><value>SIN</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = 'cosine(360) + sine(90)'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
@@ -550,73 +682,125 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Double value like contains', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="SetXBrick"><commentedOut>false</commentedOut><formulaList><formula category="X_POSITION"><leftChild><type>NUMBER</type><value>3</value></leftChild><rightChild><type>NUMBER</type><value>1</value></rightChild><type>FUNCTION</type><value>CONTAINS</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetXBrick"><commentedOut>false</commentedOut><formulaList><formula category="X_POSITION"><leftChild><type>NUMBER</type><value>3</value></leftChild><rightChild><type>NUMBER</type><value>1</value></rightChild><type>FUNCTION</type><value>CONTAINS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = 'contains(3, 1)'.trim();
-
+          const splitIndex = formulaMap.entries().next().value.toString().indexOf(',');
+          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex).trim();
+          const firstMapValue = formulaMap
+            .entries()
+            .next()
+            .value.toString()
+            .slice(splitIndex + 1)
+            .trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='X_POSITION']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'SetXBrick' &&
+            firstMapKey === 'X_POSITION' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('Sensor action in formular', async () => {
+    test('Sensor action in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>SENSOR</type><value>COLLIDES_WITH_FINGER</value></leftChild><rightChild><type>FUNCTION</type><value>TRUE</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>SENSOR</type><value>COLLIDES_WITH_FINGER</value></leftChild><rightChild><type>FUNCTION</type><value>TRUE</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = 'touches finger + true'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('UserList in formular', async () => {
+    test('UserList in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_LIST</type><value>tvariable</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_LIST</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = '*tvariable*'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('UserVariable in formular', async () => {
+    test('UserVariable in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_VARIABLE</type><value>tvariable</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_VARIABLE</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = '"tvariable"'.trim();
-
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();
     });
 
-    test('String in formular', async () => {
+    test('String in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const scriptString = `<script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>STRING</type><value>hello</value></leftChild><rightChild><type>STRING</type><value> world</value></rightChild><type>FUNCTION</type><value>JOIN</value></formula></formulaList></brick></brickList></script>`;
-          const scriptXml = parser.convertScriptString(scriptString);
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>STRING</type><value>hello</value></leftChild><rightChild><type>STRING</type><value> world</value></rightChild><type>FUNCTION</type><value>JOIN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const programJSON = parser.convertProgramToJSONDebug(xmlString);
+          if (programJSON === undefined) {
+            return false;
+          }
+          const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
+          const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
           const refString = "join('hello', 'world')".trim();
-
+          const splitIndex = formulaMap.entries().next().value.toString().indexOf(',');
+          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex).trim();
+          const firstMapValue = formulaMap
+            .entries()
+            .next()
+            .value.toString()
+            .slice(splitIndex + 1)
+            .trim();
           return (
-            scriptXml instanceof XMLDocument &&
-            scriptXml.querySelector(`field[name='TIME_TO_WAIT_IN_SECONDS']`).innerHTML.trim() === refString
+            formulaMap.size === 1 &&
+            block === 'WaitBrick' &&
+            firstMapKey === 'TIME_TO_WAIT_IN_SECONDS' &&
+            firstMapValue === refString
           );
         })
       ).toBeTruthy();

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -46,7 +46,7 @@ describe('Share basic tests', () => {
         const container = document.createElement('div');
         shareTestContainer.append(container);
 
-        share.renderObjectJSON('tobject', 'sceneID-accordionObjects', container, undefined, { name: 'objectName' });
+        share.renderObjectJSON('tobject', 'sceneID-accordionObjects', container, { name: 'objectName' });
 
         const objectCard = container.firstChild;
 
@@ -76,11 +76,10 @@ describe('Share catroid program rendering tests', () => {
   test('Share render unsupported version properly', async () => {
     expect(
       await page.evaluate(() => {
-        const catXml = undefined;
         const catObj = undefined;
 
         try {
-          share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+          share.renderProgramJSON('programID', shareTestContainer, catObj);
           return false;
         } catch (e) {
           return (
@@ -95,12 +94,10 @@ describe('Share catroid program rendering tests', () => {
   test('Share render an empty program properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {};
 
         try {
-          share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+          share.renderProgramJSON('programID', shareTestContainer, catObj);
           return false;
         } catch (e) {
           return (
@@ -115,8 +112,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render a single empty scene properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -125,7 +120,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         return (
           shareTestContainer.querySelector('.catblocks-scene') !== null &&
@@ -142,8 +137,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render multiple empty scenes properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene1"></scene><scene type="tscene2"></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -155,7 +148,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         return (
           shareTestContainer.querySelector('.catblocks-scene') !== null &&
@@ -172,8 +165,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render a single empty object properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -187,7 +178,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         return (
           shareTestContainer.querySelector('.catblocks-object .card-header') !== null &&
@@ -204,8 +195,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render multiple empty objects in same scene', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject1"></object><object type="tobject2"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -222,7 +211,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const sceneID = shareUtils.generateID('programID-tscene');
         const obj1ID = shareUtils.generateID('programID-tscene-tobject1');
@@ -245,8 +234,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render empty objects in different scenes', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene1"><object type="tobject1"></object></scene><scene type="tscene2"><object type="tobject2"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -268,7 +255,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const scene1ID = shareUtils.generateID('programID-tscene1');
         const scene2ID = shareUtils.generateID('programID-tscene2');
@@ -295,14 +282,22 @@ describe('Share catroid program rendering tests', () => {
   test('Share render script svg', async () => {
     expect(
       await page.evaluate(() => {
-        const scriptString = `<block type="PreviousLookBrick"></block>`;
-        const scriptXml = new DOMParser().parseFromString(scriptString, 'text/xml');
-        const svg = share.domToSvg(scriptXml);
-
+        const scriptJSON = {
+          name: 'StartScript',
+          brickList: [
+            {
+              name: 'SetXBrick',
+              loopOrIfBrickList: [],
+              elseBrickList: [],
+              formValues: {},
+              colorVariation: 0
+            }
+          ],
+          formValues: {}
+        };
+        const svg = share.domToSvg(scriptJSON);
         return (
-          svg !== null &&
-          svg.getAttribute('class') === 'catblocks-svg' &&
-          svg.querySelector('path.blocklyPath') !== null
+          svg !== null && svg.textContent.includes('When scene starts') && svg.textContent.includes('Set x tounset')
         );
       })
     ).toBeTruthy();
@@ -311,12 +306,25 @@ describe('Share catroid program rendering tests', () => {
   test('Share render svg script box properly', async () => {
     expect(
       await page.evaluate(() => {
-        const scriptString = `<block type="PreviousLookBrick"></block>`;
-        const scriptXml = new DOMParser().parseFromString(scriptString, 'text/xml');
-        const svg = share.domToSvg(scriptXml);
+        const scriptJSON = {
+          name: 'StartScript',
+          brickList: [
+            {
+              name: 'SetXBrick',
+              loopOrIfBrickList: [],
+              elseBrickList: [],
+              formValues: {},
+              colorVariation: 0
+            }
+          ],
+          formValues: {}
+        };
+        const svg = share.domToSvg(scriptJSON);
 
         return (
           svg !== null &&
+          svg.textContent.includes('When scene starts') &&
+          svg.textContent.includes('Set x tounset') &&
           svg.getAttribute('width').replace('px', '') > 0 &&
           svg.getAttribute('height').replace('px', '') > 0
         );
@@ -327,8 +335,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share render single empty scriptlist properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject"><script type="tscript"><block type="PreviousLookBrick"></block></script></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -347,7 +353,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const objID = shareUtils.generateID('programID-tscene-tobject');
         return (
@@ -363,14 +369,6 @@ describe('Share catroid program rendering tests', () => {
     expect(
       await page.evaluate(() => {
         const testDisplayName = 'Silence Sound';
-        const xmlString = `
-      <xml>
-        <scene type="tscene">
-          <object type="tobject">
-          </object>
-        </scene>
-      </xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -390,24 +388,22 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const objID = shareUtils.generateID('programID-tscene-tobject');
         return (
           shareTestContainer.querySelector('#' + objID + ' #' + objID + '-sounds .catblocks-object-sound-name') !=
             null &&
           shareTestContainer.querySelector('#' + objID + ' #' + objID + '-sounds .catblocks-object-sound-name')
-            .innerHTML == testDisplayName
+            .innerHTML === testDisplayName
         );
       })
     ).toBeTruthy();
   });
 
-  test('JSON object has a script, but XML not', async () => {
+  test('JSON object has a script', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject">/object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -425,24 +421,19 @@ describe('Share catroid program rendering tests', () => {
             }
           ]
         };
-
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
-
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
         const objID = shareUtils.generateID('programID-tscene-tobject');
-        return (
-          shareTestContainer.querySelector(
-            '#' + objID + ' #' + objID + '-scripts .catblocks-script svg.catblocks-svg'
-          ) == null
+        const executeQuery = shareTestContainer.querySelector(
+          '#' + objID + ' #' + objID + '-scripts .catblocks-script svg.catblocks-svg'
         );
+        return Object.keys(executeQuery).length === 0;
       })
     ).toBeTruthy();
   });
 
-  test('JSON and XML have unqual number of scenes', async () => {
+  test('JSON with one scene', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene1"></scene><scene type="tscene2"></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -452,7 +443,7 @@ describe('Share catroid program rendering tests', () => {
         };
 
         try {
-          share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+          share.renderProgramJSON('programID', shareTestContainer, catObj);
         } catch (e) {
           return false;
         }
@@ -460,11 +451,9 @@ describe('Share catroid program rendering tests', () => {
     ).toBeFalsy();
   });
 
-  test('JSON and XML have unqual number of objects in scene', async () => {
+  test('JSON with two objects in scene rendered properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject1"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -481,7 +470,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
 
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         return (
           shareTestContainer.querySelector('.catblocks-scene') !== null &&
@@ -489,7 +478,8 @@ describe('Share catroid program rendering tests', () => {
           shareTestContainer.querySelector('.catblocks-object-container') !== null &&
           shareTestContainer.querySelector('.accordion') !== null &&
           shareTestContainer.querySelector('.catblocks-object .card-header') !== null &&
-          shareTestContainer.querySelector('.catblocks-object .card-header').innerHTML.startsWith('No objects found')
+          shareTestContainer.querySelector('.catblocks-object .card-header').innerHTML ===
+            '<div style="font-weight: normal;">tobject1</div><i class="material-icons">chevron_left</i>'
         );
       })
     ).toBeTruthy();
@@ -498,12 +488,10 @@ describe('Share catroid program rendering tests', () => {
   test('JSON empty but XML given', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject1"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {};
 
         try {
-          share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+          share.renderProgramJSON('programID', shareTestContainer, catObj);
         } catch (e) {
           return false;
         }
@@ -514,8 +502,6 @@ describe('Share catroid program rendering tests', () => {
   test('Share renders scene and card headers properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<xml><scene type="tscene"><object type="tobject"></object></scene></xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -528,7 +514,7 @@ describe('Share catroid program rendering tests', () => {
             }
           ]
         };
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const expectedSceneHeaderTextCollapsed =
           '<div style="font-weight: normal;">tscene</div><i class="material-icons">chevron_left</i>';
@@ -564,128 +550,5 @@ describe('Share catroid program rendering tests', () => {
         );
       })
     ).toBeTruthy();
-  });
-});
-
-describe('Share statistic tests', () => {
-  describe('Update objects statistic tests', () => {
-    test('Check update status function against undefined and null', async () => {
-      expect(
-        await page.evaluate(() => {
-          const objectStats = {
-            name: 'tobject',
-            scripts: 0
-          };
-          const addNull = share.updateObjectStats(objectStats, null);
-          const addUndefined = share.updateObjectStats(objectStats, undefined);
-
-          return (
-            JSON.stringify(addNull) === JSON.stringify(objectStats) &&
-            JSON.stringify(addUndefined) === JSON.stringify(objectStats)
-          );
-        })
-      ).toBeTruthy();
-    });
-
-    test('Add empty script to existing object statistic', async () => {
-      expect(
-        await page.evaluate(() => {
-          const objectStats = {
-            name: 'tobject',
-            scripts: 1,
-            look: 1
-          };
-          const updatedStats = share.updateObjectStats(objectStats, {});
-
-          return (
-            JSON.stringify(updatedStats) ===
-            JSON.stringify({
-              name: 'tobject',
-              scripts: 2,
-              look: 1
-            })
-          );
-        })
-      ).toBeTruthy();
-    });
-
-    test('Add script to existing object statistic', async () => {
-      expect(
-        await page.evaluate(() => {
-          const objectStats = {
-            name: 'tobject',
-            scripts: 1,
-            sound: 1,
-            pen: 2,
-            control: 5
-          };
-          const updatedStats = share.updateObjectStats(objectStats, { looks: 1, sound: 2, control: 0 });
-
-          return (
-            JSON.stringify(updatedStats) ===
-            JSON.stringify({
-              name: 'tobject',
-              scripts: 2,
-              sound: 3,
-              pen: 2,
-              control: 5,
-              looks: 1
-            })
-          );
-        })
-      ).toBeTruthy();
-    });
-  });
-
-  describe('Fetch script statistic tests', () => {
-    test('Check get script stats function against undefined and null', async () => {
-      expect(
-        await page.evaluate(() => {
-          const nullScriptStats = share.getScriptStats(null);
-          const undefinedScriptStats = share.getScriptStats(undefined);
-
-          return (
-            JSON.stringify(nullScriptStats) === JSON.stringify({}) &&
-            JSON.stringify(undefinedScriptStats) === JSON.stringify({})
-          );
-        })
-      ).toBeTruthy();
-    });
-
-    test('Share fetches properly stats from empty script', async () => {
-      expect(
-        await page.evaluate(() => {
-          const scriptString = `<script type="tscript"></script>`;
-          const scriptXml = new DOMParser().parseFromString(scriptString, 'text/xml');
-          const scriptStats = share.getScriptStats(scriptXml);
-
-          return JSON.stringify(scriptStats) === JSON.stringify({});
-        })
-      ).toBeTruthy();
-    });
-
-    test('Share fetches properly stats from script with one block', async () => {
-      expect(
-        await page.evaluate(() => {
-          const scriptString = `<script type="tscript"><block type="PreviousLookBrick"></block></script>`;
-          const scriptXml = new DOMParser().parseFromString(scriptString, 'text/xml');
-          const scriptStats = share.getScriptStats(scriptXml);
-
-          return JSON.stringify(scriptStats) === JSON.stringify({ looks: 1 });
-        })
-      ).toBeTruthy();
-    });
-
-    test('Share fetches properly stats from unknown script', async () => {
-      expect(
-        await page.evaluate(() => {
-          const scriptString = `<script type="tscript"><block type="unknownBrick"></block></script>`;
-          const scriptXml = new DOMParser().parseFromString(scriptString, 'text/xml');
-          const scriptStats = share.getScriptStats(scriptXml);
-
-          return JSON.stringify(scriptStats) === JSON.stringify({ unknown: 1 });
-        })
-      ).toBeTruthy();
-    });
   });
 });

--- a/test/jsunit/share/share.utils.test.js
+++ b/test/jsunit/share/share.utils.test.js
@@ -40,26 +40,6 @@ describe('Share utilities testing', () => {
     ).toBeTruthy();
   });
 
-  test('Transform xml performs properly', async () => {
-    expect(
-      await page.evaluate(() => {
-        const xmlDoc = new DOMParser().parseFromString(
-          '<xml><scene id="tscene" class="value"><block class="tclass">innerValue</block></scene></xml>',
-          'text/xml'
-        );
-        shareUtils.transformXml(xmlDoc, {
-          block: ['remAttr-class'],
-          scene: ['remAttr-class', 'remAttr-x']
-        });
-
-        return (
-          '<xml><scene id="tscene"><block>innerValue</block></scene></xml>' ===
-          new XMLSerializer().serializeToString(xmlDoc)
-        );
-      })
-    ).toBeTruthy();
-  });
-
   test('Inject dom node performs properly', async () => {
     expect(
       await page.evaluate(() => {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-111

Created new jsonDomToWorkspace function in utils to render blocks with json object.
So I deleted all unnecessary xml code in parser and fixed all tests. 

I changed the "from xml" function in playground to "from json" and also fixed "import using parser". 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
