### PR TITLE
BLOCKS-118 Unknown regional language suffixes handled incorrectly

### DIFF
--- a/i18n/create_msg.js
+++ b/i18n/create_msg.js
@@ -58,8 +58,13 @@ Blockly.CatblocksMsgs.setLocale = function(locale, filesLocation = undefined) {
       return Promise.resolve();
     }
   } else {
-    console.warn('Fallback to default language and ignoring unrecognized locale: ' + locale);
-    return Blockly.CatblocksMsgs.setLocale(Blockly.CatblocksMsgs.currentLocale_);
+    const localeWithoutSuffix = locale.substring(0, locale.indexOf('_'));
+    if (locale !== localeWithoutSuffix) {
+      return Blockly.CatblocksMsgs.setLocale(localeWithoutSuffix, filesLocation);
+    } else {
+      console.warn('Fallback to default language and ignoring unrecognized locale: ' + locale);
+      return Blockly.CatblocksMsgs.setLocale(Blockly.CatblocksMsgs.currentLocale_, filesLocation);
+    }
   }
 };
 

--- a/src/js/catblocks_msgs.js
+++ b/src/js/catblocks_msgs.js
@@ -26,8 +26,13 @@ Blockly.CatblocksMsgs.setLocale = function (locale, filesLocation = undefined) {
       return Promise.resolve();
     }
   } else {
-    console.warn('Fallback to default language and ignoring unrecognized locale: ' + locale);
-    return Blockly.CatblocksMsgs.setLocale(Blockly.CatblocksMsgs.currentLocale_);
+    const localeWithoutSuffix = locale.substring(0, locale.indexOf('_'));
+    if (locale !== localeWithoutSuffix) {
+      return Blockly.CatblocksMsgs.setLocale(localeWithoutSuffix, filesLocation);
+    } else {
+      console.warn('Fallback to default language and ignoring unrecognized locale: ' + locale);
+      return Blockly.CatblocksMsgs.setLocale(Blockly.CatblocksMsgs.currentLocale_, filesLocation);
+    }
   }
 };
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,13 +12,7 @@ import { renderAllPrograms } from './render/render';
 
   let language = 'en';
   if (process.env.DISPLAY_LANGUAGE !== undefined && process.env.DISPLAY_LANGUAGE.length > 0) {
-    const values = Blockly.CatblocksMsgs.locales[process.env.DISPLAY_LANGUAGE];
-    if (values === undefined) {
-      console.warn('no language found for ' + process.env.DISPLAY_LANGUAGE + '. set to default.');
-      language = 'en';
-    } else {
-      language = process.env.DISPLAY_LANGUAGE;
-    }
+    language = process.env.DISPLAY_LANGUAGE;
   }
   await Blockly.CatblocksMsgs.setLocale(language);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -20,7 +20,6 @@ import { renderAllPrograms } from './render/render';
       language = process.env.DISPLAY_LANGUAGE;
     }
   }
-  console.log(language);
   await Blockly.CatblocksMsgs.setLocale(language);
 
   switch (process.env.TYPE) {

--- a/test/jsunit/msg/msg.test.js
+++ b/test/jsunit/msg/msg.test.js
@@ -64,8 +64,6 @@ describe('Filesystem msg tests', () => {
 describe('Webview test', () => {
   beforeEach(async () => {
     await page.goto(`${SERVER}`, { waitUntil: 'networkidle0' });
-    page.on('console', message => console.log(message.text()));
-    // clean workspace before each test
     await page.evaluate(() => {
       playgroundWS.clear();
     });
@@ -198,7 +196,6 @@ describe('Webview test', () => {
 describe('share displays language of UI elements correctly', () => {
   beforeEach(async () => {
     await page.goto(`${SERVER}`, { waitUntil: 'networkidle0' });
-    page.on('console', message => console.log(message.text()));
   });
 
   test('check >en< language of tabs and error messages of scripts, looks and sounds', async () => {
@@ -219,6 +216,42 @@ describe('share displays language of UI elements correctly', () => {
       return Blockly.CatblocksMsgs.setLocale(testLanguage);
     }, testLanguage);
     expect(await executeShareLanguageUITest(testLanguageObject)).toBeTruthy();
+  });
+
+  test('check if unknown >es_US< language is handled as >es<', async () => {
+    const testLanguage = 'es_US';
+    const fallbackLanguage = 'es';
+    const fallbackLanguageObject = JSON.parse(
+      utils.readFileSync(`${utils.PATHS.CATBLOCKS_MSGS}${fallbackLanguage}.json`)
+    );
+    await page.evaluate(testLanguage => {
+      return Blockly.CatblocksMsgs.setLocale(testLanguage);
+    }, testLanguage);
+    expect(await executeShareLanguageUITest(fallbackLanguageObject)).toBeTruthy();
+  });
+
+  test('check if invalid >de_XY< language is handled as >de<', async () => {
+    const testLanguage = 'de_XY';
+    const fallbackLanguage = 'de';
+    const fallbackLanguageObject = JSON.parse(
+      utils.readFileSync(`${utils.PATHS.CATBLOCKS_MSGS}${fallbackLanguage}.json`)
+    );
+    await page.evaluate(testLanguage => {
+      return Blockly.CatblocksMsgs.setLocale(testLanguage);
+    }, testLanguage);
+    expect(await executeShareLanguageUITest(fallbackLanguageObject)).toBeTruthy();
+  });
+
+  test('check if >xy_za< language is handled as default >en<', async () => {
+    const testLanguage = 'xy_za';
+    const fallbackLanguage = 'en';
+    const fallbackLanguageObject = JSON.parse(
+      utils.readFileSync(`${utils.PATHS.CATBLOCKS_MSGS}${fallbackLanguage}.json`)
+    );
+    await page.evaluate(testLanguage => {
+      return Blockly.CatblocksMsgs.setLocale(testLanguage);
+    }, testLanguage);
+    expect(await executeShareLanguageUITest(fallbackLanguageObject)).toBeTruthy();
   });
 
   async function executeShareLanguageUITest(languageObject) {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-118

If regional language suffix is unknown then the same language without the regional suffix is used. If this language is still unknown then the implementation uses the fallback language 'en'.

Created three tests to check if the current implementation works properly. 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
