### PR TITLE
BLOCKS-127 Add check for GH Actions

### DIFF
--- a/.github/workflows/merge_actions.yaml
+++ b/.github/workflows/merge_actions.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deployTestingpage:
+    if: github.repository == 'Catrobat/Catblocks'
     name: Deploy Testpage to GH-Pages
     runs-on: ubuntu-latest
     steps:
@@ -14,6 +15,7 @@ jobs:
       uses: ./gh-pages-deploy-action/
     
   rerunTests:
+    if: github.repository == 'Catrobat/Catblocks'
     name: Restart all Pull Request Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request_actions.yml
+++ b/.github/workflows/pull_request_actions.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   runTests:
+    if: github.repository == 'Catrobat/Catblocks'
     name: Run Auto-Tests
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +27,7 @@ jobs:
           path: /home/runner/work/Catblocks/Catblocks/catblocksTestReport/
       
   uploadDocker:
+    if: github.repository == 'Catrobat/Catblocks'
     name: Create new artifact for PO review
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +43,7 @@ jobs:
 
 
   lintCode:
+    if: github.repository == 'Catrobat/Catblocks'
     name: Lint Code
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
A check ensures that actions are only executed on the GH Repository Catrobat/Catblocks. The problem is that on forked repositories they always fail.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
