### PR TITLE
BLOCKS-91 Support right to left languages: bricks

### DIFF
--- a/docker/po-review/README.md
+++ b/docker/po-review/README.md
@@ -35,6 +35,7 @@ In case you have already built the `catblocks:po-review` container and you would
 You can set the display language by adding following option `-e DISPLAY_LANGUAGE=de`. E.g. `de` for German. Without this option the blocks will be rendered with the default language.
 Use key values of locales from `i18n/lang_codes_mapping.js` to set display language.
 
+It is also possible to change the layout to RTL. You only have to add following option `-e DISPLAY_RTL=true`. Then the share layout displays right to left. 
 ## Single program testing
 For single program testing use the paramater method. 
 Here you just pass, either the program URL or the program hash, as paramaters to the container.
@@ -49,6 +50,9 @@ Both values can be found on the [share](https://share.catrob.at/app/).
 
   # use program hash and set display language to German
   docker run --rm -it -e DISPLAY_LANGUAGE=de -p 8080:8080 catblocks:po-review "4a20f223-5cbf-11ea-a2ae-000c292a0f49" 
+
+  # use program hash and set RTL 
+  docker run --rm -it -e DISPLAY_RTL=true -p 8080:8080 catblocks:po-review "4a20f223-5cbf-11ea-a2ae-000c292a0f49" 
 ```
 
 This will download the program before launching the webserver.
@@ -77,4 +81,7 @@ can be done using the `-v` option.
 
  # mount folder, set language to German and run bulk test
   docker run --rm -it -e DISPLAY_LANGUAGE=de -v ./catBulkTest:/test/programs/ -p 8080:8080 catblocks:po-review
+
+ # mount folder, set RTL and run bulk test
+  docker run --rm -it -e DISPLAY_RTL=true -v ./catBulkTest:/test/programs/ -p 8080:8080 catblocks:po-review
 ```

--- a/src/intern/js/index.js
+++ b/src/intern/js/index.js
@@ -12,8 +12,12 @@ import { initShareAndRenderPrograms } from './render/utils';
   }
 
   let language = 'en';
+  let isRtl = false;
   if (process.env.DISPLAY_LANGUAGE !== undefined && process.env.DISPLAY_LANGUAGE.length > 0) {
     language = process.env.DISPLAY_LANGUAGE;
+  }
+  if (process.env.DISPLAY_RTL !== undefined && process.env.DISPLAY_RTL.toLowerCase() === 'true') {
+    isRtl = true;
   }
   await Blockly.CatblocksMsgs.setLocale(language);
 
@@ -25,7 +29,7 @@ import { initShareAndRenderPrograms } from './render/utils';
     }
     case 'render': {
       const programPath = 'assets/programs/';
-      initShareAndRenderPrograms(programPath, language);
+      initShareAndRenderPrograms(programPath, language, isRtl);
       break;
     }
     case 'testing': {
@@ -37,6 +41,7 @@ import { initShareAndRenderPrograms } from './render/utils';
         shareRoot: '',
         media: 'media/',
         language: language,
+        rtl: isRtl,
         noImageFound: 'No_Image_Available.jpg'
       });
       window.share = CatBlocks.getInstance().share;

--- a/src/intern/js/render/utils.js
+++ b/src/intern/js/render/utils.js
@@ -168,8 +168,9 @@ export async function loadArchive(containerfile) {
  *
  * @param {string} programPath
  * @param {string} language
+ * @param {boolean} isRtl
  */
-export async function initShareAndRenderPrograms(programPath, language) {
+export async function initShareAndRenderPrograms(programPath, language, isRtl) {
   const catblocksWorkspaceContainer = 'catblocks-workspace-container';
   const programContainer = document.getElementById('catblocks-programs-container');
   const i18nLocation = window.location.href + 'i18n/';
@@ -179,6 +180,7 @@ export async function initShareAndRenderPrograms(programPath, language) {
     shareRoot: '',
     media: 'media/',
     language: language,
+    rtl: isRtl,
     i18n: i18nLocation,
     noImageFound: 'No_Image_Available.jpg'
   });

--- a/src/library/html/release.html
+++ b/src/library/html/release.html
@@ -24,6 +24,7 @@
           container: 'catblocks-program-container',
           renderSize: 0.75,
           language: 'de',
+          rtl: false,
           shareRoot: 'http://localhost:8080/', // support for http(s)://
           media: 'media/', // and relative path to shareRoot
           i18n: '/i18n', // and absolute path from host/

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -30,12 +30,13 @@ export class Share {
   init(options) {
     this.config = parseOptions(options, defaultOptions.render);
     this.createReadonlyWorkspace();
-
     // for now only convert when in library
     if (window.CatBlocks) {
       this.insertRightMediaURI();
     }
-
+    if (this.config.rtl) {
+      document.documentElement.style.direction = 'rtl';
+    }
     Blockly.CatblocksMsgs.setLocale(this.config.language, this.config.i18n);
   }
 
@@ -77,7 +78,6 @@ export class Share {
     if (this.config.media.startsWith('http') || this.config.media.startsWith('/')) {
       mediapath = this.config.media;
     }
-
     this.workspace = this.blockly.inject(hiddenContainer, {
       readOnly: true,
       media: mediapath,
@@ -86,7 +86,8 @@ export class Share {
         wheel: false,
         startScale: this.config.renderSize
       },
-      renderer: 'zelos'
+      renderer: 'zelos',
+      rtl: this.config.rtl
     });
 
     this.workspaceDom = this.workspace.getInjectionDiv();
@@ -107,8 +108,6 @@ export class Share {
       zebraChangeColor(this.workspace.topBlocks_);
       const oriSvg = this.workspace.getParentSvg();
       const oriBox = oriSvg.lastElementChild.getBBox();
-
-      // remove rect around it
       svg = oriSvg.cloneNode(true);
       svg.lastElementChild.removeChild(svg.lastElementChild.firstElementChild);
       svg.setAttribute('width', `${sceneWidth * this.config.renderSize}px`);
@@ -397,7 +396,7 @@ export class Share {
    * @param {Element} container
    * @param {string} objectID
    * @param {Object} object
-   * @param {Oject} currentLocaleValues
+   * @param {Object} currentLocaleValues
    * @param {Object} [options=defaultOptions.object]
    */
   generateLooks(container, objectID, object, currentLocaleValues, options = defaultOptions.object) {
@@ -489,7 +488,6 @@ export class Share {
    * @param {string} objectID
    * @param {Object} object
    * @param {Object} currentLocaleValues
-   * @param {Object} [options=defaultOptions.object]
    */
   generateScripts(container, objectID, object, currentLocaleValues) {
     const wrapperContainer = injectNewDom(container, 'div', {
@@ -518,6 +516,9 @@ export class Share {
       const scriptContainer = injectNewDom(wrapperContainer, 'div', {
         class: 'catblocks-script'
       });
+      if (this.config.rtl) {
+        scriptContainer.style.textAlign = 'right';
+      }
       scriptContainer.style.overflowX = 'auto';
 
       const blockSvg = this.domToSvg(object.scriptList[i]);

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -295,9 +295,11 @@ describe('Share catroid program rendering tests', () => {
           ],
           formValues: {}
         };
-        const svg = share.domToSvg(scriptJSON);
+        const svg = share.domToSvg(scriptJSON, 0);
         return (
-          svg !== null && svg.textContent.includes('When scene starts') && svg.textContent.includes('Set x tounset')
+          svg.textContent.replace(/\s/g, ' ').includes('When scene starts') &&
+          svg.textContent.replace(/\s/g, ' ').includes('Set x to') &&
+          svg.textContent.replace(/\s/g, ' ').includes('unset')
         );
       })
     ).toBeTruthy();
@@ -319,12 +321,12 @@ describe('Share catroid program rendering tests', () => {
           ],
           formValues: {}
         };
-        const svg = share.domToSvg(scriptJSON);
-
+        const svg = share.domToSvg(scriptJSON, 0);
         return (
           svg !== null &&
-          svg.textContent.includes('When scene starts') &&
-          svg.textContent.includes('Set x tounset') &&
+          svg.textContent.replace(/\s/g, ' ').includes('When scene starts') &&
+          svg.textContent.replace(/\s/g, ' ').includes('Set x to') &&
+          svg.textContent.replace(/\s/g, ' ').includes('unset') &&
           svg.getAttribute('width').replace('px', '') > 0 &&
           svg.getAttribute('height').replace('px', '') > 0
         );
@@ -352,9 +354,7 @@ describe('Share catroid program rendering tests', () => {
             }
           ]
         };
-
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-
         const objID = shareUtils.generateID('programID-tscene-tobject');
         return (
           shareTestContainer.querySelector(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,8 @@ module.exports = {
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development',
       TYPE: 'catblocks',
-      DISPLAY_LANGUAGE: process.env.DISPLAY_LANGUAGE ? process.env.DISPLAY_LANGUAGE : ""
+      DISPLAY_LANGUAGE: process.env.DISPLAY_LANGUAGE ? process.env.DISPLAY_LANGUAGE : "",
+      DISPLAY_RTL: process.env.DISPLAY_RTL ? process.env.DISPLAY_RTL : ""
     }),
     new PrettierPlugin()
   ],


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-91

All blocks can be displayed in RTL now. 
To test this implementation locally: set in index.js at line 14 `let isRtl = true;`. 
You can also test this implementation with po-review docker, please add  `-e DISPLAY_RTL=true` to the run command (see readme for more details).

There are still some issues left on this topic ([BLOCKS-92](https://jira.catrob.at/browse/BLOCKS-92) and [BLOCKS-93](https://jira.catrob.at/browse/BLOCKS-92)).

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
