### PR TITLE
BLOCKS-120 Catblocks Renderer is not working

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -72,12 +72,14 @@ function initShareAndRenderPrograms(programPath, language) {
   const catblocksWorkspaceContainer = 'catblocks-workspace-container';
   const programContainer = document.getElementById('catblocks-programs-container');
   const share = new Share();
+  const i18nLocation = window.location.href + 'i18n/';
   share.init({
     container: catblocksWorkspaceContainer,
     renderSize: 0.75,
     shareRoot: '',
     media: 'media/',
     language: language,
+    i18n: i18nLocation,
     noImageFound: 'No_Image_Available.jpg'
   });
   renderAllPrograms(share, programContainer, programPath);


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-120

added i18n folder attribute to share/render config. Catblocks Renderer should work again. 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
