### PR TITLE
Blocks 89: Show larger version of look when the user taps on it in the list of looks, in a popup

### DIFF
--- a/src/intern/html/render.html
+++ b/src/intern/html/render.html
@@ -28,6 +28,27 @@
         <span class="small">Only .catrobat Files supported</span>
       </div>
     </div>
+
+    <div class="modal" id="modalForImg">
+      <div class="modal-dialog">
+        <div class="modal-content">
+
+          <div class="modal-header">
+            <span id="modalHeader"></span>
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+          </div>
+
+          <div class="modal-body">
+            <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%" >
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div id="catblocks-workspace-container"></div>
     <div id="catblocks-programs-container"></div>
     <div id="loading-overlay">

--- a/src/intern/html/render.html
+++ b/src/intern/html/render.html
@@ -32,14 +32,13 @@
     <div class="modal" id="modalForImg">
       <div class="modal-dialog">
         <div class="modal-content">
-
           <div class="modal-header">
             <span id="modalHeader"></span>
             <button type="button" class="close" data-dismiss="modal">&times;</button>
           </div>
 
           <div class="modal-body">
-            <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%" >
+            <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%;" />
           </div>
 
           <div class="modal-footer">

--- a/src/intern/html/testing.html
+++ b/src/intern/html/testing.html
@@ -23,7 +23,29 @@
       </div>
       <div id="share">
         <h2>Share testing</h2>
-        <div id="shareprogs"></div>
+        <div id="shareprogs">
+
+          <div class="modal" id="modalForImg">
+            <div class="modal-dialog">
+              <div class="modal-content">
+
+                <div class="modal-header">
+                  <span id="modalHeader"></span>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+                </div>
+
+                <div class="modal-body">
+                  <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%" >
+                </div>
+
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
       </div>
     </main>
 

--- a/src/intern/html/testing.html
+++ b/src/intern/html/testing.html
@@ -24,18 +24,16 @@
       <div id="share">
         <h2>Share testing</h2>
         <div id="shareprogs">
-
           <div class="modal" id="modalForImg">
             <div class="modal-dialog">
               <div class="modal-content">
-
                 <div class="modal-header">
                   <span id="modalHeader"></span>
                   <button type="button" class="close" data-dismiss="modal">&times;</button>
                 </div>
 
                 <div class="modal-body">
-                  <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%" >
+                  <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%;" />
                 </div>
 
                 <div class="modal-footer">
@@ -44,7 +42,6 @@
               </div>
             </div>
           </div>
-
         </div>
       </div>
     </main>

--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -118,7 +118,5 @@ img {
 }
 
 .search {
-    border: none;
+  border: none;
 }
-
-

--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -116,3 +116,9 @@ img {
 .catblocks-object-sound-item {
   width: 100%;
 }
+
+.search {
+    border: none;
+}
+
+

--- a/src/library/html/release.html
+++ b/src/library/html/release.html
@@ -18,7 +18,6 @@
 
   <body>
     <div id="catblocks-program-container">
-
       <div class="modal" id="modalForImg">
         <div class="modal-dialog">
           <div class="modal-content">
@@ -37,7 +36,6 @@
           </div>
         </div>
       </div>
-
     </div>
     <script>
       window.onload = function () {

--- a/src/library/html/release.html
+++ b/src/library/html/release.html
@@ -17,7 +17,28 @@
   </head>
 
   <body>
-    <div id="catblocks-program-container"></div>
+    <div id="catblocks-program-container">
+
+      <div class="modal" id="modalForImg">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <span id="modalHeader"></span>
+              <button type="button" class="close" data-dismiss="modal">&times;</button>
+            </div>
+
+            <div class="modal-body">
+              <img src="" id="modalImg" class="imagepreview" style="width: 100%; height: 100%;" />
+            </div>
+
+            <div class="modal-footer">
+              <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
     <script>
       window.onload = function () {
         CatBlocks.init({

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -443,10 +443,13 @@ export class Share {
     let failed = 0;
     for (const look of object.lookList) {
       const row = injectNewDom(group, 'div', {
-        class: 'list-group-item row'
+        class: 'list-group-item align-items-center'
       });
       const col = injectNewDom(row, 'div', {
         class: 'col-3'
+      });
+      const button = injectNewDom(row, 'span', {
+        class: 'align-items-center'
       });
 
       if (!options.sceneName || !look.fileName) {
@@ -466,10 +469,24 @@ export class Share {
         src = options.fileMap[imgPath];
       }
 
+      let displayLookName = look.name;
+      if (!displayLookName) {
+        displayLookName = look.fileName;
+      }
+
+      const imgID = `${displayLookName}-imgID`;
       injectNewDom(col, 'img', {
         src: src,
-        class: 'img-fluid catblocks-object-look-item'
-      });
+        class: 'img-fluid catblocks-object-look-item',
+        id: imgID,
+        'data-toggle': 'modal',
+        'data-target': '#modalForImg',
+      }, displayLookName);
+
+      document.getElementById(imgID).onclick = function(){
+        document.getElementById("modalHeader").innerHTML = displayLookName;
+        document.getElementById("modalImg").src = this.src;
+      };
 
       const lookName = injectNewDom(
         row,
@@ -479,9 +496,26 @@ export class Share {
         },
         look.name
       );
+
+      const magnifyingGlassID = "button " + displayLookName;
+      const magnifyingGlass = injectNewDom(button, 'button', {
+        class: 'search',
+        id: magnifyingGlassID,
+        'data-toggle': 'modal',
+        'data-target': '#modalForImg',
+        name: 'not clicked'
+      });
+      magnifyingGlass.innerHTML = '<i class="material-icons">search</i>';
+      document.getElementById(magnifyingGlassID).onclick = function(){
+        document.getElementById("modalHeader").innerHTML = displayLookName;
+        document.getElementById("modalImg").src = src;
+        magnifyingGlass.name = 'now got clicked!';
+      };
+
       if (this.config.rtl) {
         lookName.style.textAlign = 'right';
       }
+
     }
 
     if (failed > 0) {

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -475,17 +475,22 @@ export class Share {
       }
 
       const imgID = `${displayLookName}-imgID`;
-      injectNewDom(col, 'img', {
-        src: src,
-        class: 'img-fluid catblocks-object-look-item',
-        id: imgID,
-        'data-toggle': 'modal',
-        'data-target': '#modalForImg',
-      }, displayLookName);
+      injectNewDom(
+        col,
+        'img',
+        {
+          src: src,
+          class: 'img-fluid catblocks-object-look-item',
+          id: imgID,
+          'data-toggle': 'modal',
+          'data-target': '#modalForImg'
+        },
+        displayLookName
+      );
 
-      document.getElementById(imgID).onclick = function(){
-        document.getElementById("modalHeader").innerHTML = displayLookName;
-        document.getElementById("modalImg").src = this.src;
+      document.getElementById(imgID).onclick = function () {
+        document.getElementById('modalHeader').innerHTML = displayLookName;
+        document.getElementById('modalImg').src = this.src;
       };
 
       const lookName = injectNewDom(
@@ -497,7 +502,7 @@ export class Share {
         look.name
       );
 
-      const magnifyingGlassID = "button " + displayLookName;
+      const magnifyingGlassID = 'button ' + displayLookName;
       const magnifyingGlass = injectNewDom(button, 'button', {
         class: 'search',
         id: magnifyingGlassID,
@@ -506,9 +511,9 @@ export class Share {
         name: 'not clicked'
       });
       magnifyingGlass.innerHTML = '<i class="material-icons">search</i>';
-      document.getElementById(magnifyingGlassID).onclick = function(){
-        document.getElementById("modalHeader").innerHTML = displayLookName;
-        document.getElementById("modalImg").src = src;
+      document.getElementById(magnifyingGlassID).onclick = function () {
+        document.getElementById('modalHeader').innerHTML = displayLookName;
+        document.getElementById('modalImg').src = src;
         magnifyingGlass.name = 'now got clicked!';
       };
 

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -520,7 +520,6 @@ export class Share {
       if (this.config.rtl) {
         lookName.style.textAlign = 'right';
       }
-
     }
 
     if (failed > 0) {

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -432,9 +432,10 @@ describe('Share catroid program rendering tests', () => {
   });
 
   test('Share render object with magnifying glass in look tab and simulate click to popup image', async () => {
-    expect(await page.evaluate(() => {
-      const testDisplayName = 'My actor';
-      const xmlString = `
+    expect(
+      await page.evaluate(() => {
+        const testDisplayName = 'My actor';
+        const xmlString = `
       <xml>
         <scene type="tscene">
           <object type="tobject">
@@ -444,34 +445,48 @@ describe('Share catroid program rendering tests', () => {
           </object>
         </scene>
       </xml>`;
-      const catXml = (new DOMParser).parseFromString(xmlString, 'text/xml');
-      const catObj = {
-        scenes: [{
-          name: 'tscene',
-          objectList: [{
-            name: 'tobject',
-            lookList: [{
-              name: testDisplayName,
-              fileName: 'My actor or object.png'
-            }]
-          }]
-        }]
-      };
-      share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
-      const objID = shareUtils.generateID('programID-tscene-tobject');
-      const expectedID = testDisplayName + '-imgID';
-      const expectedSrc = shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item').src;
+        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
+        const catObj = {
+          scenes: [
+            {
+              name: 'tscene',
+              objectList: [
+                {
+                  name: 'tobject',
+                  lookList: [
+                    {
+                      name: testDisplayName,
+                      fileName: 'My actor or object.png'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        const objID = shareUtils.generateID('programID-tscene-tobject');
+        const expectedID = testDisplayName + '-imgID';
+        const expectedSrc = shareTestContainer.querySelector(
+          '#' + objID + ' #' + objID + '-looks .catblocks-object-look-item'
+        ).src;
 
-      shareTestContainer.querySelector('.catblocks-scene-header').click();
-      shareTestContainer.querySelector('.catblocks-object .card-header').click();
-      shareTestContainer.querySelector('#'+objID+'-looks-tab').click();
-      shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .search').click();
+        shareTestContainer.querySelector('.catblocks-scene-header').click();
+        shareTestContainer.querySelector('.catblocks-object .card-header').click();
+        shareTestContainer.querySelector('#' + objID + '-looks-tab').click();
+        shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .search').click();
 
-      return (shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item') !== null
-        && shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .search').innerHTML === '<i class="material-icons">search</i>'
-        && shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item').id === expectedID
-        && shareTestContainer.querySelector('.imagepreview').src === expectedSrc);
-    })).toBeTruthy();
+        return (
+          shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .catblocks-object-look-item') !==
+            null &&
+          shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .search').innerHTML ===
+            '<i class="material-icons">search</i>' &&
+          shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .catblocks-object-look-item').id ===
+            expectedID &&
+          shareTestContainer.querySelector('.imagepreview').src === expectedSrc
+        );
+      })
+    ).toBeTruthy();
   });
 
   test('JSON with one scene', async () => {

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -431,6 +431,49 @@ describe('Share catroid program rendering tests', () => {
     ).toBeTruthy();
   });
 
+  test('Share render object with magnifying glass in look tab and simulate click to popup image', async () => {
+    expect(await page.evaluate(() => {
+      const testDisplayName = 'My actor';
+      const xmlString = `
+      <xml>
+        <scene type="tscene">
+          <object type="tobject">
+            <lookList>
+              <look fileName="My actor or object.png" name="My actor"/>
+            </lookList>
+          </object>
+        </scene>
+      </xml>`;
+      const catXml = (new DOMParser).parseFromString(xmlString, 'text/xml');
+      const catObj = {
+        scenes: [{
+          name: 'tscene',
+          objectList: [{
+            name: 'tobject',
+            lookList: [{
+              name: testDisplayName,
+              fileName: 'My actor or object.png'
+            }]
+          }]
+        }]
+      };
+      share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+      const objID = shareUtils.generateID('programID-tscene-tobject');
+      const expectedID = testDisplayName + '-imgID';
+      const expectedSrc = shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item').src;
+
+      shareTestContainer.querySelector('.catblocks-scene-header').click();
+      shareTestContainer.querySelector('.catblocks-object .card-header').click();
+      shareTestContainer.querySelector('#'+objID+'-looks-tab').click();
+      shareTestContainer.querySelector('#' + objID + ' #' + objID + '-looks .search').click();
+
+      return (shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item') !== null
+        && shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .search').innerHTML === '<i class="material-icons">search</i>'
+        && shareTestContainer.querySelector('#'+objID+' #'+objID+'-looks .catblocks-object-look-item').id === expectedID
+        && shareTestContainer.querySelector('.imagepreview').src === expectedSrc);
+    })).toBeTruthy();
+  });
+
   test('JSON with one scene', async () => {
     expect(
       await page.evaluate(() => {


### PR DESCRIPTION
Added a magnifying glass button and an onclick() event on the image in share, to popup the image in a modal in the center of the screen.
Created a test in share.test.js for the popup, which should only open by clicking on the magnifying glass beside the image or by clicking on the image.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
