### PR TITLE
BLOCKS-92 Support right to left languages: formula

### DIFF
--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -496,7 +496,6 @@ export class Share {
       role: 'tabpanel',
       'aria-labelledby': `${objectID}-scripts-tab`
     });
-
     if (!object || !object.scriptList || object.scriptList.length <= 0) {
       const noScriptText = 'No ' + currentLocaleValues['SCRIPTS'] + ' found';
       wrapperContainer.appendChild(

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -295,7 +295,7 @@ describe('Share catroid program rendering tests', () => {
           ],
           formValues: {}
         };
-        const svg = share.domToSvg(scriptJSON, 0);
+        const svg = share.domToSvg(scriptJSON);
         return (
           svg.textContent.replace(/\s/g, ' ').includes('When scene starts') &&
           svg.textContent.replace(/\s/g, ' ').includes('Set x to') &&
@@ -321,7 +321,7 @@ describe('Share catroid program rendering tests', () => {
           ],
           formValues: {}
         };
-        const svg = share.domToSvg(scriptJSON, 0);
+        const svg = share.domToSvg(scriptJSON);
         return (
           svg !== null &&
           svg.textContent.replace(/\s/g, ' ').includes('When scene starts') &&


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-92

Formulas are displayed in RTL too. 
To test this implementation locally: set in index.js at line 14 let isRtl = true;.
You can also test this implementation with po-review docker, please add -e DISPLAY_RTL=true to the run command (see readme for more details).

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
