### PR TITLE
BLOCKS-93 Support right to left languages: share layout

### DIFF
--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -268,6 +268,11 @@ export class Share {
       'aria-controls': objCollapseOneSceneID
     });
 
+    if (this.config.rtl) {
+      cardHeader.style.paddingLeft = '1.5em';
+      cardHeader.style.paddingRight = '3.5em';
+    }
+
     if (object && object.name) {
       cardHeader.innerHTML = `<div style="font-weight: normal;">${object.name}</div><i class="material-icons">chevron_left</i>`;
     } else {
@@ -320,6 +325,9 @@ export class Share {
           noSoundsText
         )
       );
+      if (this.config.rtl) {
+        soundsContainer.style.textAlign = 'right';
+      }
       return;
     }
 
@@ -358,7 +366,7 @@ export class Share {
         displaySoundName = sound.fileName;
       }
 
-      injectNewDom(
+      const soundName = injectNewDom(
         col,
         'span',
         {
@@ -366,6 +374,9 @@ export class Share {
         },
         displaySoundName
       );
+      if (this.config.rtl) {
+        soundName.style.textAlign = 'right';
+      }
 
       const audioContainer = injectNewDom(col, 'audio', {
         class: 'catblocks-object-sound-item',
@@ -419,6 +430,9 @@ export class Share {
           noLooksText
         )
       );
+      if (this.config.rtl) {
+        looksContainer.style.textAlign = 'right';
+      }
       return;
     }
 
@@ -457,7 +471,7 @@ export class Share {
         class: 'img-fluid catblocks-object-look-item'
       });
 
-      injectNewDom(
+      const lookName = injectNewDom(
         row,
         'div',
         {
@@ -465,6 +479,9 @@ export class Share {
         },
         look.name
       );
+      if (this.config.rtl) {
+        lookName.style.textAlign = 'right';
+      }
     }
 
     if (failed > 0) {
@@ -508,6 +525,9 @@ export class Share {
           noScriptText
         )
       );
+      if (this.config.rtl) {
+        wrapperContainer.style.textAlign = 'right';
+      }
       return;
     }
     let failed = 0;


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-93

share supports right to left layout. 
To test this implementation locally: set in index.js at line 14 let isRtl = true;.
You can also test this implementation with po-review docker, please add -e DISPLAY_RTL=true to the run command (see readme for more details).

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
