### PR TITLE
BLOCKS-138 Catblocks Renderer is still not working

### DIFF
--- a/src/intern/html/playground.html
+++ b/src/intern/html/playground.html
@@ -42,7 +42,7 @@
         <option value="top">Top</option>
         <option value="bottom">Bottom</option>
       </select>
-      <select name="locale" onchange="Catblocks.setLocale(this.value)"> </select>
+      <select name="locale" id="locale"> </select>
       <!-- gets filled by JS -->
     </form>
 

--- a/src/intern/js/index.js
+++ b/src/intern/js/index.js
@@ -19,23 +19,24 @@ import { initShareAndRenderPrograms } from './render/utils';
   if (process.env.DISPLAY_RTL !== undefined && process.env.DISPLAY_RTL.toLowerCase() === 'true') {
     isRtl = true;
   }
-  await Blockly.CatblocksMsgs.setLocale(language);
 
   switch (process.env.TYPE) {
     case 'playground': {
+      await Blockly.CatblocksMsgs.setLocale(language);
       const app = new Playground();
       app.init();
       break;
     }
     case 'render': {
       const programPath = 'assets/programs/';
-      initShareAndRenderPrograms(programPath, language, isRtl);
+      await initShareAndRenderPrograms(programPath, language, isRtl);
       break;
     }
     case 'testing': {
+      await Blockly.CatblocksMsgs.setLocale(language);
       window.Blockly = Blockly;
       window.playground = new Playground();
-      CatBlocks.init({
+      await CatBlocks.init({
         container: 'share',
         renderSize: 0.75,
         shareRoot: '',

--- a/src/intern/js/playground/playground.js
+++ b/src/intern/js/playground/playground.js
@@ -107,6 +107,7 @@ export class Playground {
       e.preventDefault();
       this.workspace.setVisible(false);
     });
+    $('#locale').change(() => this.setLocale(document.forms.options.elements.locale.value));
 
     $('#exportToXML').click(() => this.toXml());
     $('#importFromJSON').click(() => this.fromJSON());

--- a/src/intern/js/render/utils.js
+++ b/src/intern/js/render/utils.js
@@ -174,7 +174,7 @@ export async function initShareAndRenderPrograms(programPath, language, isRtl) {
   const catblocksWorkspaceContainer = 'catblocks-workspace-container';
   const programContainer = document.getElementById('catblocks-programs-container');
   const i18nLocation = window.location.href + 'i18n/';
-  CatBlocks.init({
+  await CatBlocks.init({
     container: catblocksWorkspaceContainer,
     renderSize: 0.75,
     shareRoot: '',

--- a/src/library/html/release.html
+++ b/src/library/html/release.html
@@ -38,8 +38,8 @@
       </div>
     </div>
     <script>
-      window.onload = function () {
-        CatBlocks.init({
+      window.onload = async function () {
+        await CatBlocks.init({
           container: 'catblocks-program-container',
           renderSize: 0.75,
           language: 'de',

--- a/src/library/js/lib.js
+++ b/src/library/js/lib.js
@@ -19,7 +19,7 @@ export class CatBlocks {
    * @export
    * @param {*} config
    */
-  static init(config) {
+  static async init(config) {
     if (!config) {
       throw new Error('No configuration given');
     }
@@ -29,7 +29,7 @@ export class CatBlocks {
     preparePaths();
 
     catblocks_instance.share = new Share();
-    catblocks_instance.share.init(config);
+    await catblocks_instance.share.init(config);
   }
 
   /**

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -27,7 +27,7 @@ export class Share {
    * init share class instance
    * @param {Element} options for rendering process
    */
-  init(options) {
+  async init(options) {
     this.config = parseOptions(options, defaultOptions.render);
     this.createReadonlyWorkspace();
     // for now only convert when in library
@@ -37,7 +37,7 @@ export class Share {
     if (this.config.rtl) {
       document.documentElement.style.direction = 'rtl';
     }
-    Blockly.CatblocksMsgs.setLocale(this.config.language, this.config.i18n);
+    await Blockly.CatblocksMsgs.setLocale(this.config.language, this.config.i18n);
   }
 
   /**


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-138

Removed the `setLocale()` function call without i18n folder as second parameter in index.js. Now Catblocks Renderer should work again. 

Also changing language on playground is working again.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
