### PR TITLE
BLOCKS-123 Expand More rotation should use CSS from Share

### DIFF
--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -117,6 +117,22 @@ img {
   width: 100%;
 }
 
+[data-toggle='collapse'][aria-expanded='true'] .rotate-left {
+  transform: rotate(-90deg);
+}
+
+.rotate-left {
+  transition: 0.3s transform ease;
+  transition-property: transform;
+  transition-duration: 0.3s;
+  transition-timing-function: ease;
+  transition-delay: 0s;
+}
+
+[data-toggle='collapse'][aria-expanded='true'] .header-title {
+  font-weight: bold;
+}
+
 .search {
   border: none;
 }

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -145,11 +145,10 @@ export class Share {
     });
 
     if (sceneName) {
-      sceneHeader.innerHTML = `<div style="font-weight: normal;">${sceneName}</div><i class="material-icons">chevron_left</i>`;
+      sceneHeader.innerHTML = `<div class="header-title">${sceneName}</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>`;
     } else {
-      sceneHeader.innerHTML = `<i class="material-icons">chevron_left</i>`;
+      sceneHeader.innerHTML = `<i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>`;
     }
-    $(`#${sceneID}-header`).click(() => this.changeHeaderDesign(sceneHeader));
 
     const sceneObjectContainer = injectNewDom(sceneContainer, 'div', {
       class: 'catblocks-object-container collapse',
@@ -274,11 +273,10 @@ export class Share {
     }
 
     if (object && object.name) {
-      cardHeader.innerHTML = `<div style="font-weight: normal;">${object.name}</div><i class="material-icons">chevron_left</i>`;
+      cardHeader.innerHTML = `<div class="header-title">${object.name}</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>`;
     } else {
-      cardHeader.innerHTML = `<i class="material-icons">chevron_left</i>`;
+      cardHeader.innerHTML = `<i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>`;
     }
-    $(`#${objHeadingID}`).click(() => this.changeHeaderDesign(cardHeader));
 
     const objectContentContainer = injectNewDom(objectCard, 'div', {
       class: 'collapse',
@@ -709,37 +707,5 @@ export class Share {
     });
 
     return col;
-  }
-
-  /**
-   * handle click events on scene headers and card headers
-   * change chevron direction and set title bold/normal
-   * @param {Element} sceneElement
-   */
-  changeHeaderDesign(sceneElement) {
-    const parentContainer = sceneElement.parentElement.parentElement;
-    const ariaExpanded = sceneElement.getAttribute('aria-expanded');
-    const divElement = sceneElement.children[0];
-    const iElement = sceneElement.children[1];
-    //set design for current element
-    if (iElement.textContent.includes('chevron_left') && ariaExpanded === 'false') {
-      iElement.textContent = iElement.textContent.replace('chevron_left', 'expand_more');
-      divElement.style.fontWeight = 'bold';
-    } else {
-      if (iElement.textContent.includes('expand_more') && ariaExpanded === 'true') {
-        iElement.textContent = iElement.textContent.replace('expand_more', 'chevron_left');
-        divElement.style.fontWeight = 'normal';
-      } else {
-        console.error("can't change chevron and header title: " + sceneElement.getAttribute('class'));
-      }
-    }
-    //set design for all other elements in the same parent div
-    for (let i = 0; i < parentContainer.children.length; i++) {
-      const element = parentContainer.children[i].children[0];
-      if (element !== sceneElement) {
-        element.children[0].style.fontWeight = 'normal';
-        element.children[1].textContent = iElement.textContent.replace('expand_more', 'chevron_left');
-      }
-    }
   }
 }

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -184,7 +184,7 @@ describe('Share catroid program rendering tests', () => {
           shareTestContainer.querySelector('.catblocks-object .card-header') !== null &&
           shareTestContainer
             .querySelector('.catblocks-object .card-header')
-            .innerHTML.startsWith('<div style="font-weight: normal;">tobject</div>') &&
+            .innerHTML.startsWith('<div class="header-title">tobject</div>') &&
           shareTestContainer.querySelector('.tab-pane') !== null &&
           shareTestContainer.querySelector('.catblocks-script') === null
         );
@@ -537,7 +537,7 @@ describe('Share catroid program rendering tests', () => {
           shareTestContainer.querySelector('.accordion') !== null &&
           shareTestContainer.querySelector('.catblocks-object .card-header') !== null &&
           shareTestContainer.querySelector('.catblocks-object .card-header').innerHTML ===
-            '<div style="font-weight: normal;">tobject1</div><i class="material-icons">chevron_left</i>'
+            '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>'
         );
       })
     ).toBeTruthy();
@@ -574,14 +574,10 @@ describe('Share catroid program rendering tests', () => {
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
-        const expectedSceneHeaderTextCollapsed =
-          '<div style="font-weight: normal;">tscene</div><i class="material-icons">chevron_left</i>';
-        const expectedCardHeaderTextCollapsed =
-          '<div style="font-weight: normal;">tobject</div><i class="material-icons">chevron_left</i>';
-        const expectedSceneHeaderTextExpanded =
-          '<div style="font-weight: bold;">tscene</div><i class="material-icons">expand_more</i>';
-        const expectedCardHeaderTextExpanded =
-          '<div style="font-weight: bold;">tobject</div><i class="material-icons">expand_more</i>';
+        const expectedSceneHeaderText =
+          '<div class="header-title">tscene</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+        const expectedCardHeaderText =
+          '<div class="header-title">tobject</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
         const sceneHeaderInitialText = sceneHeader.innerHTML;
@@ -599,15 +595,18 @@ describe('Share catroid program rendering tests', () => {
         const sceneHeaderTextCollapsed = sceneHeader.innerHTML;
         const cardHeaderTextCollapsed = cardHeader.innerHTML;
         return (
-          sceneHeaderInitialText === expectedSceneHeaderTextCollapsed &&
-          cardHeaderInitialText === expectedCardHeaderTextCollapsed &&
-          sceneHeaderTextExpanded === expectedSceneHeaderTextExpanded &&
-          cardHeaderTextExpanded === expectedCardHeaderTextExpanded &&
-          sceneHeaderTextCollapsed === expectedSceneHeaderTextCollapsed &&
-          cardHeaderTextCollapsed === expectedCardHeaderTextCollapsed
+          sceneHeaderInitialText === expectedSceneHeaderText &&
+          cardHeaderInitialText === expectedCardHeaderText &&
+          sceneHeaderTextExpanded === expectedSceneHeaderText &&
+          cardHeaderTextExpanded === expectedCardHeaderText &&
+          sceneHeaderTextCollapsed === expectedSceneHeaderText &&
+          cardHeaderTextCollapsed === expectedCardHeaderText
         );
       })
     ).toBeTruthy();
+    await page.waitForSelector('.catblocks-object .card-header', {
+      visible: true
+    });
   });
 
   test('scrolling bricks on x axis on mobile share page is working', async () => {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-123

Removed our custom js function and added css class to handle chevron rotation. Now scene and card headers should have the same behavior as the card headers on [share](https://share.catrob.at/app/project/4a20f223-5cbf-11ea-a2ae-000c292a0f49).

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
