### PR TITLE
BLOCKS-145: fixed zebra bug, where color didn't reset properly

### DIFF
--- a/src/library/js/share/utils.js
+++ b/src/library/js/share/utils.js
@@ -168,63 +168,39 @@ export const trimString = (str, length = 15) => {
   return undefined;
 };
 
-export const resetColorBlock = array => {
-  for (let i = 0; i < array.length; i++) {
-    if (array[i].style.colour_ === array[i].style.colourPrimary) {
-      const colorPrimaryTemporary = array[i].style.colourPrimary;
-      array[i].style.colourPrimary = array[i].style.colourTertiary;
-      array[i].style.colourTertiary = colorPrimaryTemporary;
-    }
-    if (array[i].childBlocks_.length > 0) {
-      for (let j = 0; j < array[i].childBlocks_.length; j++) {
-        if (array[i].childBlocks_[j].style.colour_ === array[i].childBlocks_[j].style.colourPrimary) {
-          const colorPrimaryTemporary = array[i].childBlocks_[j].style.colourPrimary;
-          array[i].childBlocks_[j].style.colourPrimary = array[i].childBlocks_[j].style.colourTertiary;
-          array[i].childBlocks_[j].style.colourTertiary = colorPrimaryTemporary;
-        }
-      }
-      resetColorBlock(array[i].childBlocks_);
-    }
-  }
-};
-
 /**
  * zebra effect -> color next block from same group slightly differently
  * @param {*} array
- * @param {boolean} firstCall
  */
-export const checkNextBlock = (array, firstCall = false) => {
+export const zebraChangeColor = array => {
+  checkNextBlock(array);
+};
+
+/**
+ * zebra effect helper function
+ * @param {*} array
+ */
+export const checkNextBlock = array => {
   for (let i = 0; i < array.length; i++) {
     if (array[i].childBlocks_.length > 0) {
       for (let j = 0; j < array[i].childBlocks_.length; j++) {
-        if (array[i].style.colourPrimary === array[i].childBlocks_[j].style.colourPrimary) {
+        if (array[i].colour_ === array[i].childBlocks_[j].colour_) {
           const colorPrimaryTemporary = array[i].childBlocks_[j].style.colourPrimary;
           const colorTertiaryTemporary = array[i].childBlocks_[j].style.colourTertiary;
 
-          array[i].childBlocks_[j].style.colour_ = colorTertiaryTemporary;
-          array[i].childBlocks_[j].style.colourPrimary = colorTertiaryTemporary;
+          array[i].childBlocks_[j].colour_ = array[i].childBlocks_[j].style.colourTertiary;
+          array[i].childBlocks_[j].style.colourPrimary = array[i].childBlocks_[j].style.colourTertiary;
           array[i].childBlocks_[j].style.colourTertiary = colorPrimaryTemporary;
 
           array[i].childBlocks_[j].initSvg();
 
-          if (
-            firstCall &&
-            array[i].childBlocks_[j].childBlocks_.length > 0 &&
-            colorPrimaryTemporary !== array[i].childBlocks_[j].childBlocks_[0].style.colourTertiary
-          ) {
-            array[i].childBlocks_[j].style.colourPrimary = colorPrimaryTemporary;
-            array[i].childBlocks_[j].style.colourTertiary = colorTertiaryTemporary;
-          }
+          array[i].childBlocks_[j].style.colourPrimary = colorPrimaryTemporary;
+          array[i].childBlocks_[j].style.colourTertiary = colorTertiaryTemporary;
         }
       }
       checkNextBlock(array[i].childBlocks_);
     }
   }
-};
-
-export const zebraChangeColor = array => {
-  checkNextBlock(array, true);
-  resetColorBlock(array);
 };
 
 /**

--- a/test/jsunit/block/block.test.js
+++ b/test/jsunit/block/block.test.js
@@ -271,7 +271,7 @@ describe('WebView Block tests', () => {
           topBlock.childBlocks_[0].childBlocks_.push(playgroundWS.newBlock('WaitBrick'));
           topBlock.childBlocks_[0].childBlocks_[0].childBlocks_.push(playgroundWS.newBlock('WaitBrick'));
           playground.zebra();
-          return topBlock.colour_ === topBlock.childBlocks_[0].childBlocks_[0].style.colour_;
+          return topBlock.colour_ === topBlock.childBlocks_[0].childBlocks_[0].colour_ && topBlock.colour_ !== topBlock.childBlocks_[0].colour_;
         })
       ).toBeTruthy();
     });

--- a/test/jsunit/block/block.test.js
+++ b/test/jsunit/block/block.test.js
@@ -271,7 +271,10 @@ describe('WebView Block tests', () => {
           topBlock.childBlocks_[0].childBlocks_.push(playgroundWS.newBlock('WaitBrick'));
           topBlock.childBlocks_[0].childBlocks_[0].childBlocks_.push(playgroundWS.newBlock('WaitBrick'));
           playground.zebra();
-          return topBlock.colour_ === topBlock.childBlocks_[0].childBlocks_[0].colour_ && topBlock.colour_ !== topBlock.childBlocks_[0].colour_;
+          return (
+            topBlock.colour_ === topBlock.childBlocks_[0].childBlocks_[0].colour_ &&
+            topBlock.colour_ !== topBlock.childBlocks_[0].colour_
+          );
         })
       ).toBeTruthy();
     });


### PR DESCRIPTION
Zebra was working, but not properly, because if it was dark at the end of one script, it started dark at the next, which shouldn't be anymore.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
