### PR TITLE
BLOCKS-141 catroid-support-checker-action is not working

### DIFF
--- a/.github/workflows/interval_catroid_check_action.yaml
+++ b/.github/workflows/interval_catroid_check_action.yaml
@@ -3,6 +3,7 @@ name: Interval Action for brick support and language update check
 on:
     schedule:
         - cron: '0 7 * * 1' # Mondays 7AM UTC
+        - cron: '0 7 * * 4' # Thursdays 7AM UTC
 
 jobs:
     runDocker:

--- a/catroid-support-checker-action/entrypoint.sh
+++ b/catroid-support-checker-action/entrypoint.sh
@@ -11,7 +11,7 @@ git clone $CATBLOCKS
 git clone $CATROID
 
 # copy the json-files to the working directory
-cp -r Catblocks/src/js/blocks/categories categories
+cp -r Catblocks/src/library/js/blocks/categories categories
 
 # run checker & send report
 python3 /checker.py "$WORKDIR" "$1"

--- a/catroid-support-checker-action/require/checker.py
+++ b/catroid-support-checker-action/require/checker.py
@@ -199,31 +199,38 @@ def sendSlackMessage(webhook, message):
 def main():
     path = sys.argv[1]
     slack_webhook = sys.argv[2]
-    slack_msg = ""
-    send_msg = False
+    try:
+        slack_msg = ""
+        send_msg = False
 
-    # load bricks and compare them
-    java_bricks = loadCatroidBricks(path)
-    js_bricks = loadCatblocksBricks(path)
-    in_java_not_js, in_js_not_java = compareBricks(java_bricks, js_bricks)
+        # load bricks and compare them
+        java_bricks = loadCatroidBricks(path)
+        js_bricks = loadCatblocksBricks(path)
+        in_java_not_js, in_js_not_java = compareBricks(java_bricks, js_bricks)
 
-    # generate slack report for bricks if necessary
-    if in_java_not_js is not None and len(in_java_not_js) > 0:
-        category_class = loadJavaCategoryClass(path).splitlines()
-        slack_msg += generateBlockMessage(in_java_not_js, category_class)
-        send_msg = True
+        # generate slack report for bricks if necessary
+        if in_java_not_js is not None and len(in_java_not_js) > 0:
+            category_class = loadJavaCategoryClass(path).splitlines()
+            slack_msg += generateBlockMessage(in_java_not_js, category_class)
+            send_msg = True
 
-    # compare languages
-    catroid_languages = loadSupportedCatroidLanguages(path)
-    catblocks_languages = loadSupportedCatblocksLanguages(path)
-    language_updates = compareLanguageSupport(catroid_languages, catblocks_languages)
-    
-    if language_updates is not None and len(language_updates) > 0:
-        slack_msg += '\n\n' + generateLanguageMessage(language_updates)
-        send_msg = True
+        # compare languages
+        catroid_languages = loadSupportedCatroidLanguages(path)
+        catblocks_languages = loadSupportedCatblocksLanguages(path)
+        language_updates = compareLanguageSupport(catroid_languages, catblocks_languages)
 
-    if send_msg:
-        sendSlackMessage(slack_webhook, slack_msg.strip())
+        if language_updates is not None and len(language_updates) > 0:
+            slack_msg += '\n\n' + generateLanguageMessage(language_updates)
+            send_msg = True
+
+        if send_msg:
+            sendSlackMessage(slack_webhook, slack_msg.strip())
+        else:
+            slack_msg = "Everything is up to date."
+            sendSlackMessage(slack_webhook, slack_msg.strip())
+    except:
+        slack_msg = "Failed to execute checker.py"
+        sendSlackMessage(slack_webhook, slack_msg.strip()
 
 if __name__ == '__main__':
     main()

--- a/catroid-support-checker-action/require/checker.py
+++ b/catroid-support-checker-action/require/checker.py
@@ -230,7 +230,7 @@ def main():
             sendSlackMessage(slack_webhook, slack_msg.strip())
     except:
         slack_msg = "Failed to execute checker.py"
-        sendSlackMessage(slack_webhook, slack_msg.strip()
+        sendSlackMessage(slack_webhook, slack_msg.strip())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-141

checker.py is working again. Now a slack message is also generated when there are no changes detected or when the script is failing. Script is now executed twice a week (on Mondays and on Thursdays at 7 am). 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
