### PR TITLE
BLOCKS-137 Display rendering time when testing

### DIFF
--- a/src/intern/js/index.js
+++ b/src/intern/js/index.js
@@ -45,6 +45,7 @@ import { initShareAndRenderPrograms } from './render/utils';
         rtl: isRtl,
         noImageFound: 'No_Image_Available.jpg'
       });
+      window.CatBlocks = CatBlocks;
       window.share = CatBlocks.getInstance().share;
       window.shareUtils = shareUtils;
       window.playground.workspace = Blockly.inject('playworkspace', {

--- a/test/jsunit/performance/performance.test.js
+++ b/test/jsunit/performance/performance.test.js
@@ -1,0 +1,25 @@
+/**
+ * @description Block tests
+ */
+/* global CatBlocks, page, SERVER */
+/* eslint no-global-assign:0 */
+'use strict';
+
+describe('Performance tests', () => {
+  beforeAll(async () => {
+    await page.goto(`${SERVER}`, { waitUntil: 'networkidle0' });
+  });
+  test('Rendering test program takes less than 30 seconds', async () => {
+    jest.setTimeout(40000);
+    expect(
+      await page.evaluate(() => {
+        const startTime = performance.now();
+        return CatBlocks.render('assets', 'share').then(() => {
+          const endTime = performance.now();
+          const durationInSeconds = (endTime - startTime) / 1000;
+          return durationInSeconds;
+        });
+      })
+    ).toBeLessThan(30);
+  });
+});


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-137

Created new test file with one performance test to measure rendering time of the default test program (The Binding of Krishna). 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
