### PR TITLE
BLOCKS-143: added userlanguage definition for backgroundscene depende…

### DIFF
--- a/i18n/strings_to_json_mapping.json
+++ b/i18n/strings_to_json_mapping.json
@@ -526,6 +526,7 @@
   "SCRIPTS": "${scripts}",
   "LOOKS": "${looks}",
   "SOUNDS": "${sounds}",
+  "BACKGROUND": "${background}",
   "ASSERTION_TAP_AT": "${brick_tap_at} ${x_label} %1%2 ${y_label} %3%4",
   "ASSERTION_FINISH_STAGE": "${brick_finish_stage}",
   "ASSERTION_WAIT_TILL_IDLE": "${brick_wait_till_idle}",

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -292,16 +292,23 @@ export class Share {
       const spinnerModal = $('#spinnerModal');
 
       if (!renderEverything) {
-        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer);
+        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything);
         continue;
       }
 
       if (programJSON.scenes.length === 1) {
-        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer);
+        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything);
       } else {
         $('body').on('click', `#${sceneID}`, () => {
           spinnerModal.on('shown.bs.modal', () => {
-            this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer);
+            this.renderAllObjectsFromOneScene(
+              options,
+              scene,
+              programID,
+              sceneID,
+              sceneObjectContainer,
+              renderEverything
+            );
             spinnerModal.modal('hide');
           });
           if (rendered_scenes[sceneID] !== true) {
@@ -314,7 +321,9 @@ export class Share {
     container.appendChild(programContainers[0]);
   }
 
-  renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer) {
+  renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything) {
+    this.handleBackgroundName(programID, scene, sceneID, sceneObjectContainer, options, renderEverything);
+
     if (rendered_scenes[sceneID] === true) {
       return;
     }
@@ -324,7 +333,7 @@ export class Share {
     const performanceContainer = generateNewDOM(undefined, 'div');
 
     options.object.sceneName = scene.name;
-    for (let j = 0; j < scene.objectList.length; j++) {
+    for (let j = 1; j < scene.objectList.length; j++) {
       const object = scene.objectList[j];
       const objectID = generateID(`${programID}-${scene.name}-${object.name}`);
 
@@ -348,6 +357,23 @@ export class Share {
         </div>
     </div>`;
     $('body').append(loadingAnimation);
+  }
+
+  handleBackgroundName(programID, scene, sceneID, sceneObjectContainer, options, renderEverything) {
+    options.object.sceneName = scene.name;
+    const backgroundObjID = generateID(`${programID}-${scene.name}-${scene.objectList[0].name}`);
+
+    if (renderEverything) {
+      scene.objectList[0].name = Blockly.CatblocksMsgs.getCurrentLocaleValues().BACKGROUND;
+    }
+
+    this.renderObjectJSON(
+      backgroundObjID,
+      `${sceneID}-accordionObjects`,
+      sceneObjectContainer,
+      scene.objectList[0],
+      parseOptions(options.object, parseOptions(options.object, defaultOptions.object))
+    );
   }
 
   /**

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -522,7 +522,7 @@ describe('Share catroid program rendering tests', () => {
               name: 'testscene',
               objectList: [
                 {
-                  name: 'tobject1'
+                  name: 'Background'
                 },
                 {
                   name: 'tobject2'
@@ -545,7 +545,7 @@ describe('Share catroid program rendering tests', () => {
           shareTestContainer.querySelector('.accordion') !== null &&
           shareTestContainer.querySelector('.catblocks-object .card-header') !== null &&
           shareTestContainer.querySelector('.catblocks-object .card-header').innerHTML ===
-            '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>'
+            '<div class="header-title">Background</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>'
         );
       })
     ).toBeTruthy();
@@ -574,7 +574,7 @@ describe('Share catroid program rendering tests', () => {
               name: 'testscene',
               objectList: [
                 {
-                  name: 'tobject'
+                  name: 'Background'
                 }
               ]
             }
@@ -583,7 +583,7 @@ describe('Share catroid program rendering tests', () => {
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const expectedCardHeaderText =
-          '<div class="header-title">tobject</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+          '<div class="header-title">Background</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
         const cardHeaderInitialText = cardHeader.innerHTML;
         cardHeader.click();
@@ -613,7 +613,7 @@ describe('Share catroid program rendering tests', () => {
               name: 'testscene1',
               objectList: [
                 {
-                  name: 'tobject1'
+                  name: 'Background'
                 }
               ]
             },
@@ -640,7 +640,7 @@ describe('Share catroid program rendering tests', () => {
         const expectedSceneHeaderText =
           '<div class="header-title">testscene1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const expectedCardHeaderText =
-          '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+          '<div class="header-title">Background</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
         sceneHeader.click();
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');


### PR DESCRIPTION
…nt on initialization value [PL]

Now the definition of background scene is dependent on the value we set initially and currently it is hardcoded, because we use the language of the app when we migrate.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
