### PR TITLE
BLOCKS-142 Do not show scene when the project has only one scene

### DIFF
--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -204,13 +204,21 @@ export class Share {
     for (let i = 0; i < programJSON.scenes.length; i++) {
       const scene = programJSON.scenes[i];
       const sceneID = generateID(`${programID}-${scene.name}`);
-      const sceneObjectContainer = this.addSceneContainer(
-        scenesContainerID,
-        sceneID,
-        scenesContainer,
-        trimString(scene.name)
-      );
 
+      let sceneObjectContainer = undefined;
+      if (programJSON.scenes.length === 1) {
+        sceneObjectContainer = injectNewDom(scenesContainer, 'div', {
+          class: 'accordion',
+          id: `${sceneID}-accordionObjects`
+        });
+      } else {
+        sceneObjectContainer = this.addSceneContainer(
+          scenesContainerID,
+          sceneID,
+          scenesContainer,
+          trimString(scene.name)
+        );
+      }
       if (scene.objectList == null || scene.objectList.length === 0) {
         const errorContainer = injectNewDom(sceneObjectContainer, 'div', {
           class: 'catblocks-object card'

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -116,6 +116,9 @@ describe('Share catroid program rendering tests', () => {
           scenes: [
             {
               name: 'tscene'
+            },
+            {
+              name: 'tscene2'
             }
           ]
         };
@@ -207,6 +210,9 @@ describe('Share catroid program rendering tests', () => {
                   name: 'tobject2'
                 }
               ]
+            },
+            {
+              name: 'tscene2'
             }
           ]
         };
@@ -435,17 +441,6 @@ describe('Share catroid program rendering tests', () => {
     expect(
       await page.evaluate(() => {
         const testDisplayName = 'My actor';
-        const xmlString = `
-      <xml>
-        <scene type="tscene">
-          <object type="tobject">
-            <lookList>
-              <look fileName="My actor or object.png" name="My actor"/>
-            </lookList>
-          </object>
-        </scene>
-      </xml>`;
-        const catXml = new DOMParser().parseFromString(xmlString, 'text/xml');
         const catObj = {
           scenes: [
             {
@@ -461,10 +456,13 @@ describe('Share catroid program rendering tests', () => {
                   ]
                 }
               ]
+            },
+            {
+              name: 'tscene2'
             }
           ]
         };
-        share.renderProgramJSON('programID', shareTestContainer, catObj, catXml);
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
         const objID = shareUtils.generateID('programID-tscene-tobject');
         const expectedID = testDisplayName + '-imgID';
         const expectedSrc = shareTestContainer.querySelector(
@@ -524,6 +522,9 @@ describe('Share catroid program rendering tests', () => {
                   name: 'tobject2'
                 }
               ]
+            },
+            {
+              name: 'tscene2'
             }
           ]
         };
@@ -557,7 +558,7 @@ describe('Share catroid program rendering tests', () => {
     ).toBeFalsy();
   });
 
-  test('Share renders scene and card headers properly', async () => {
+  test('Share renders scene and card headers for one scene properly', async () => {
     expect(
       await page.evaluate(() => {
         const catObj = {
@@ -574,10 +575,65 @@ describe('Share catroid program rendering tests', () => {
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
-        const expectedSceneHeaderText =
-          '<div class="header-title">tscene</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const expectedCardHeaderText =
           '<div class="header-title">tobject</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+        const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
+        const cardHeaderInitialText = cardHeader.innerHTML;
+        cardHeader.click();
+        cardHeader.setAttribute('aria-expanded', 'true');
+        const cardHeaderTextExpanded = cardHeader.innerHTML;
+        cardHeader.click();
+        cardHeader.setAttribute('aria-expanded', 'false');
+        const cardHeaderTextCollapsed = cardHeader.innerHTML;
+        return (
+          cardHeaderInitialText === expectedCardHeaderText &&
+          cardHeaderTextExpanded === expectedCardHeaderText &&
+          cardHeaderTextCollapsed === expectedCardHeaderText
+        );
+      })
+    ).toBeTruthy();
+    await page.waitForSelector('.catblocks-object .card-header', {
+      visible: true
+    });
+  });
+
+  test('Share renders scene and card headers for multiple scenes properly', async () => {
+    expect(
+      await page.evaluate(() => {
+        const catObj = {
+          scenes: [
+            {
+              name: 'tscene1',
+              objectList: [
+                {
+                  name: 'tobject1'
+                }
+              ]
+            },
+            {
+              name: 'tscene2',
+              objectList: [
+                {
+                  name: 'tobject2'
+                }
+              ]
+            },
+            {
+              name: 'tscene3',
+              objectList: [
+                {
+                  name: 'tobject3'
+                }
+              ]
+            }
+          ]
+        };
+        share.renderProgramJSON('programID', shareTestContainer, catObj);
+
+        const expectedSceneHeaderText =
+          '<div class="header-title">tscene1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+        const expectedCardHeaderText =
+          '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
         const sceneHeaderInitialText = sceneHeader.innerHTML;
@@ -642,6 +698,9 @@ describe('Share catroid program rendering tests', () => {
                   ]
                 }
               ]
+            },
+            {
+              name: 'tscene2'
             }
           ]
         };


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-142

When the project has only one scene, then all objects are listed instead of the scene. 
Modified tests and added one new test. 

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
