### PR TITLE
BLOCKS-139: now objects of scenes get rendered, only when the scene g…

### DIFF
--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -234,19 +234,33 @@ export class Share {
         continue;
       }
 
-      options.object.sceneName = scene.name;
-      for (let j = 0; j < scene.objectList.length; j++) {
-        const object = scene.objectList[j];
-        const objectID = generateID(`${programID}-${scene.name}-${object.name}`);
-
-        this.renderObjectJSON(
-          objectID,
-          `${sceneID}-accordionObjects`,
-          sceneObjectContainer,
-          object,
-          parseOptions(options.object, parseOptions(options.object, defaultOptions.object))
-        );
+      if (programJSON.scenes.length === 1) {
+        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer);
+      } else {
+        let clicked = false;
+        document.getElementById(sceneID).onclick = () => {
+          if (clicked === false) {
+            this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer);
+          }
+          clicked = true;
+        };
       }
+    }
+  }
+
+  renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer) {
+    options.object.sceneName = scene.name;
+    for (let j = 0; j < scene.objectList.length; j++) {
+      const object = scene.objectList[j];
+      const objectID = generateID(`${programID}-${scene.name}-${object.name}`);
+
+      this.renderObjectJSON(
+        objectID,
+        `${sceneID}-accordionObjects`,
+        sceneObjectContainer,
+        object,
+        parseOptions(options.object, parseOptions(options.object, defaultOptions.object))
+      );
     }
   }
 

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -218,6 +218,8 @@ describe('Share catroid program rendering tests', () => {
         };
 
         share.renderProgramJSON('programID', shareTestContainer, catObj);
+        const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
+        sceneHeader.click();
 
         const sceneID = shareUtils.generateID('programID-tscene');
         const obj1ID = shareUtils.generateID('programID-tscene-tobject1');
@@ -262,9 +264,10 @@ describe('Share catroid program rendering tests', () => {
         };
 
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-
         const scene1ID = shareUtils.generateID('programID-tscene1');
         const scene2ID = shareUtils.generateID('programID-tscene2');
+        shareTestContainer.querySelector('#' + scene1ID).click();
+        shareTestContainer.querySelector('#' + scene2ID).click();
         const obj1ID = shareUtils.generateID('programID-tscene1-tobject1');
         const obj2ID = shareUtils.generateID('programID-tscene2-tobject2');
 
@@ -463,6 +466,9 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
+        const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
+        sceneHeader.click();
+
         const objID = shareUtils.generateID('programID-tscene-tobject');
         const expectedID = testDisplayName + '-imgID';
         const expectedSrc = shareTestContainer.querySelector(
@@ -530,7 +536,8 @@ describe('Share catroid program rendering tests', () => {
         };
 
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-
+        const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
+        sceneHeader.click();
         return (
           shareTestContainer.querySelector('.catblocks-scene') !== null &&
           shareTestContainer.querySelector('.catblocks-scene-header').innerHTML.length > 0 &&
@@ -635,10 +642,10 @@ describe('Share catroid program rendering tests', () => {
         const expectedCardHeaderText =
           '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
+        sceneHeader.click();
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
         const sceneHeaderInitialText = sceneHeader.innerHTML;
         const cardHeaderInitialText = cardHeader.innerHTML;
-        sceneHeader.click();
         cardHeader.click();
         sceneHeader.setAttribute('aria-expanded', 'true');
         cardHeader.setAttribute('aria-expanded', 'true');
@@ -706,9 +713,9 @@ describe('Share catroid program rendering tests', () => {
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
+        sceneHeader.click();
         const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
         const brickContainer = shareTestContainer.querySelector('.catblocks-script');
-        sceneHeader.click();
         cardHeader.click();
         const initialXPosition = brickContainer.scrollLeft;
         brickContainer.scrollBy(1, 0);


### PR DESCRIPTION
Now the objects from one scene only get rendered when you click onto the scene.

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
