### PR TITLE
BLOCKS-82 entrypoint.sh line 14 =0 not found

### DIFF
--- a/gh-pages-deploy-action/entrypoint.sh
+++ b/gh-pages-deploy-action/entrypoint.sh
@@ -11,7 +11,7 @@ cd /github/workspace/
 yarn install
 yarn clean
 yarn render:build
-$RETVALUE=$?
+RETVALUE="$?"
 
 mv ./dist ./../dist
 


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-82

Actual Behavior: gh-pages-deploy-action/entrypoint.sh: line 14: =0: not found
Expected Behavior: Retrieve return value the right way or remove the usage of return value

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
