### PR TITLE
BLOCKS-98: created automated gh-action for deploy to webtest develop branch

### DIFF
--- a/.github/workflows/merge_actions.yaml
+++ b/.github/workflows/merge_actions.yaml
@@ -5,6 +5,18 @@ on:
     branches: [ develop ] # merge creates commit + push
 
 jobs:
+  deployToShare:
+    if: github.repository == 'Catrobat/Catblocks'
+    name: Deploy Catblocks to Share
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Pull Request with Release of Catblocks to Share
+        uses: ./gh-deploy-new-develop-on-webtest/
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+
   deployTestingpage:
     if: github.repository == 'Catrobat/Catblocks'
     name: Deploy Testpage to GH-Pages

--- a/gh-deploy-new-develop-on-webtest/Dockerfile
+++ b/gh-deploy-new-develop-on-webtest/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:10-alpine
+
+MAINTAINER Catblocks "https://github.com/Catrobat/Catblocks"
+
+# enable new repositories
+RUN \
+  echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+  && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+# update and upgrade
+RUN apk --no-cache  update \
+  && apk --no-cache  upgrade
+
+# install build dependencies
+RUN \
+  apk add --no-cache --virtual .build-deps python3 make g++
+
+RUN apk add --no-cache --virtual gifsicle pngquant optipng libjpeg-turbo-utils \
+    udev ttf-opensans chromium git hub
+
+# remove cache
+RUN rm -rf /var/cache/apk/* /tmp/*
+
+# cmd
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/gh-deploy-new-develop-on-webtest/action.yml
+++ b/gh-deploy-new-develop-on-webtest/action.yml
@@ -1,0 +1,14 @@
+# action.yml
+
+name: 'gh-deploy-new-develop-webtest'
+description: 'Build docker container and build package'
+inputs:
+  github-token:
+    description: 'Github token for push'
+    required: true
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.github-token }}

--- a/gh-deploy-new-develop-on-webtest/entrypoint.sh
+++ b/gh-deploy-new-develop-on-webtest/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+: 'Catblocks create PR for develop after succesful merge'
+
+# go to checkout@v2 folder
+cd /github/workspace/
+
+GITTOKEN="$1"
+
+git reset --hard
+git clean -df
+git fetch origin develop
+git checkout develop
+
+# build release
+yarn install
+yarn clean
+yarn release:build
+$RETVALUE=$?
+
+mv ./release ./../release
+cd ..
+
+GITTOKEN="$1"
+BRANCH="gh_catblocks_automatic_deploy_develop"
+git clone https://github.com/Catrobat/Catroweb.git
+cd Catroweb/
+
+
+if git show-ref --quiet refs/heads/${BRANCH}; then
+    git fetch ${BRANCH}
+    git checkout ${BRANCH}
+else
+    git checkout -b ${BRANCH}
+fi
+
+rm -rf Catroweb/assets/catblocks/*
+mv ./../release/* ./assets/catblocks/
+
+git config user.email "action@github.com"
+git config user.name "GitHub Action"
+git add ./assets/catblocks/
+git commit -m "automatic deploy of new catblocks develop branch"
+git push "https://${GITHUB_ACTOR}:${GITTOKEN}@github.com/Catrobat/Catroweb.git" "gh_catblocks_automatic_deploy"
+hub pull-request -b develop -h gh_catblocks_automatic_deploy -m "gh-action new Catblocks publish"
+
+exit $RETVALUE


### PR DESCRIPTION
Created the docker file to automatically create a PR to the webtest develop server based on a branch at the webtest server which enables the PR for the develop branch and the branch we would use

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
