### PR TITLE
BLOCKS-155: created loading animation for lazy loading of sceneobjects

### DIFF
--- a/src/intern/js/render/render.js
+++ b/src/intern/js/render/render.js
@@ -63,11 +63,17 @@ export function renderProgramByLocalFile(container, codeXML, name, counter, file
   const programContainer = createProgramContainer(container);
 
   const programID = `catblocks-program-${name}-${counter}`;
-  CatBlocks.getInstance().share.renderProgramJSON(programID, programContainer, programJSON, {
-    object: {
-      fileMap: fileMap
-    }
-  });
+  CatBlocks.getInstance().share.renderProgramJSON(
+    programID,
+    programContainer,
+    programJSON,
+    {
+      object: {
+        fileMap: fileMap
+      }
+    },
+    true
+  );
 }
 
 /**

--- a/src/library/js/lib.js
+++ b/src/library/js/lib.js
@@ -137,10 +137,16 @@ export function renderProgram(share, container, path, name, counter = -1) {
         programID = `catblocks-program-${name}-${counter}`;
       }
 
-      share.renderProgramJSON(programID, container, programJSON, {
-        object: {
-          programRoot: `${path}${name}/`
-        }
-      });
+      share.renderProgramJSON(
+        programID,
+        container,
+        programJSON,
+        {
+          object: {
+            programRoot: `${path}${name}/`
+          }
+        },
+        true
+      );
     });
 }

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -115,10 +115,10 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene'
+              name: 'testscene'
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };
@@ -143,10 +143,10 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene1'
+              name: 'testscene1'
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };
@@ -171,7 +171,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject'
@@ -201,7 +201,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject1'
@@ -212,7 +212,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };
@@ -221,9 +221,9 @@ describe('Share catroid program rendering tests', () => {
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
         sceneHeader.click();
 
-        const sceneID = shareUtils.generateID('programID-tscene');
-        const obj1ID = shareUtils.generateID('programID-tscene-tobject1');
-        const obj2ID = shareUtils.generateID('programID-tscene-tobject2');
+        const sceneID = shareUtils.generateID('programID-testscene');
+        const obj1ID = shareUtils.generateID('programID-testscene-tobject1');
+        const obj2ID = shareUtils.generateID('programID-testscene-tobject2');
 
         return (
           shareTestContainer.querySelector('#' + shareUtils.generateID('programID')) !== null &&
@@ -245,7 +245,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene1',
+              name: 'testscene1',
               objectList: [
                 {
                   name: 'tobject1'
@@ -253,7 +253,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2',
+              name: 'testscene2',
               objectList: [
                 {
                   name: 'tobject2'
@@ -264,12 +264,12 @@ describe('Share catroid program rendering tests', () => {
         };
 
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-        const scene1ID = shareUtils.generateID('programID-tscene1');
-        const scene2ID = shareUtils.generateID('programID-tscene2');
+        const scene1ID = shareUtils.generateID('programID-testscene1');
+        const scene2ID = shareUtils.generateID('programID-testscene2');
         shareTestContainer.querySelector('#' + scene1ID).click();
         shareTestContainer.querySelector('#' + scene2ID).click();
-        const obj1ID = shareUtils.generateID('programID-tscene1-tobject1');
-        const obj2ID = shareUtils.generateID('programID-tscene2-tobject2');
+        const obj1ID = shareUtils.generateID('programID-testscene1-tobject1');
+        const obj2ID = shareUtils.generateID('programID-testscene2-tobject2');
 
         return (
           shareTestContainer.querySelector('#' + shareUtils.generateID('programID')) !== null &&
@@ -349,7 +349,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject',
@@ -364,7 +364,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-        const objID = shareUtils.generateID('programID-tscene-tobject');
+        const objID = shareUtils.generateID('programID-testscene-tobject');
         return (
           shareTestContainer.querySelector(
             '#' + objID + ' #' + objID + '-scripts .catblocks-script svg.catblocks-svg'
@@ -381,7 +381,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject',
@@ -399,7 +399,7 @@ describe('Share catroid program rendering tests', () => {
 
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
-        const objID = shareUtils.generateID('programID-tscene-tobject');
+        const objID = shareUtils.generateID('programID-testscene-tobject');
         return (
           shareTestContainer.querySelector('#' + objID + ' #' + objID + '-sounds .catblocks-object-sound-name') !=
             null &&
@@ -416,7 +416,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject',
@@ -431,7 +431,7 @@ describe('Share catroid program rendering tests', () => {
           ]
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
-        const objID = shareUtils.generateID('programID-tscene-tobject');
+        const objID = shareUtils.generateID('programID-testscene-tobject');
         const executeQuery = shareTestContainer.querySelector(
           '#' + objID + ' #' + objID + '-scripts .catblocks-script svg.catblocks-svg'
         );
@@ -447,7 +447,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject',
@@ -461,7 +461,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };
@@ -469,7 +469,7 @@ describe('Share catroid program rendering tests', () => {
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
         sceneHeader.click();
 
-        const objID = shareUtils.generateID('programID-tscene-tobject');
+        const objID = shareUtils.generateID('programID-testscene-tobject');
         const expectedID = shareUtils.generateID(`${objID}-${testDisplayName}`) + '-imgID';
         const expectedSrc = shareTestContainer.querySelector(
           '#' + objID + ' #' + objID + '-looks .catblocks-object-look-item'
@@ -499,7 +499,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene1'
+              name: 'testscene1'
             }
           ]
         };
@@ -519,7 +519,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject1'
@@ -530,7 +530,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };
@@ -571,7 +571,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene',
+              name: 'testscene',
               objectList: [
                 {
                   name: 'tobject'
@@ -610,7 +610,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'tscene1',
+              name: 'testscene1',
               objectList: [
                 {
                   name: 'tobject1'
@@ -618,7 +618,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2',
+              name: 'testscene2',
               objectList: [
                 {
                   name: 'tobject2'
@@ -626,7 +626,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene3',
+              name: 'testscene3',
               objectList: [
                 {
                   name: 'tobject3'
@@ -638,7 +638,7 @@ describe('Share catroid program rendering tests', () => {
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
         const expectedSceneHeaderText =
-          '<div class="header-title">tscene1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
+          '<div class="header-title">testscene1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const expectedCardHeaderText =
           '<div class="header-title">tobject1</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
         const sceneHeader = shareTestContainer.querySelector('.catblocks-scene-header');
@@ -682,7 +682,7 @@ describe('Share catroid program rendering tests', () => {
         const catObj = {
           scenes: [
             {
-              name: 'TestScene',
+              name: 'Testscene',
               objectList: [
                 {
                   name: 'TestObject',
@@ -707,7 +707,7 @@ describe('Share catroid program rendering tests', () => {
               ]
             },
             {
-              name: 'tscene2'
+              name: 'testscene2'
             }
           ]
         };


### PR DESCRIPTION
created a loading animation for the lazy loading of sceneobjects, now a loading modal gets popped when you click on a scene the first time

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
