### PR TITLE
BLOCKS-168: added seperation for render

### DIFF
--- a/src/intern/js/render/render.js
+++ b/src/intern/js/render/render.js
@@ -60,7 +60,7 @@ export function renderProgramByLocalFile(container, codeXML, name, counter, file
   const programJSON = Parser.convertProgramToJSONDebug(codeXML);
 
   // prepare container for program injection
-  const programContainer = createProgramContainer(container);
+  const programContainer = createProgramContainer(container, name, counter);
 
   const programID = `catblocks-program-${name}-${counter}`;
   CatBlocks.getInstance().share.renderProgramJSON(programID, programContainer, programJSON, {
@@ -73,12 +73,18 @@ export function renderProgramByLocalFile(container, codeXML, name, counter, file
 /**
  * Create container for the program.
  * @param {Element} container Parent container for structure
+ * @param programName contains name of the file
+ * @param programCounter the current number of program rendered
  * @returns {Element} container for injecting scenes
  */
-function createProgramContainer(container) {
+function createProgramContainer(container, programName, programCounter) {
   const $programContainer = $('<div/>', {
-    class: 'catblocks-container text-dark'
+    class: 'catblocks-container text-dark catblocks-scene-header card-header collapsed',
+    text: 'Program ' + programCounter + ' / ' + programName
   });
   $(container).append($programContainer);
+  console.log(programName);
+  console.log(container);
+  console.log($programContainer);
   return $programContainer[0];
 }


### PR DESCRIPTION
added visible seperation for renderer

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
