### PR TITLE
BLOCKS-169: changed it to 1/amount of programs instead of 1/current r…

### DIFF
--- a/src/intern/js/render/file_dropper.js
+++ b/src/intern/js/render/file_dropper.js
@@ -120,7 +120,7 @@ export class FileDropper {
               containerCounter,
               result.fileMap
             );
-            MessageBox.show(`Rendered ${++finished}/${containerCounter} Programs`, 4000);
+            MessageBox.show(`Rendered ${++finished}/${inputFiles.length} Programs`, 4000);
             $('#catblocks-file-dropper').hide();
           } catch (error) {
             MessageBox.show('<b>' + containerfile.name + ':</b> ' + error);


### PR DESCRIPTION
adjusted the way the message gets displayed for the amount of programs

### Your checklist for this pull request
- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Make sure you use BLOCKS instead of CATROID in your commit message
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed (Actions)
- [X] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
