### PR TITLE
BLOCKS-189 Empty strings displayed wrong

### DIFF
--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -431,7 +431,7 @@ function parseBrick(brick) {
  * @param {*} key
  * @param {*} def
  */
-const getMsgValueOrDefault = (key, def = '---') => {
+const getMsgValueOrDefault = (key, def = '') => {
   if (key === undefined) {
     return def;
   }
@@ -444,7 +444,7 @@ const getMsgValueOrDefault = (key, def = '---') => {
  * @param {*} node
  * @param {*} def
  */
-const getNodeValueOrDefault = (node, def = '---') => {
+const getNodeValueOrDefault = (node, def = '') => {
   if (node === undefined || node.nodeValue === undefined) {
     return def;
   }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -233,7 +233,7 @@ describe('Catroid to Catblocks parser tests', () => {
     ).toBeTruthy();
   });
 
-  test('Test if default value "---" is used if no nodeValue is given', async () => {
+  test('Test if no value is used if no nodeValue is given', async () => {
     expect(
       await page.evaluate(() => {
         const xmlString = `<?xml version="1.0" encoding="UTF-8"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList /><soundList><sound fileName="testSound.png" name="testSound" /></soundList><scriptList /></object><object type="Sprite" name="цель"><lookList /><soundList /><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="testFormular"><leftChild><type>NUMBER</type><value>37</value></leftChild><rightChild><type>NUMBER</type><value>58</value></rightChild><type>FUNCTION</type><value /></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
@@ -243,7 +243,7 @@ describe('Catroid to Catblocks parser tests', () => {
         }
         const brickName = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].name;
         const formulaMap = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].formValues;
-        return brickName === 'WaitBrick' && formulaMap.entries().next().value.toString().includes('37 --- 58');
+        return brickName === 'WaitBrick' && formulaMap.entries().next().value.toString().includes('37  58');
       })
     ).toBeTruthy();
   });


### PR DESCRIPTION
Change default value of brick inputs from "---" to empty string.
https://jira.catrob.at/browse/BLOCKS-189

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
