### PR TITLE
BLOCKS-195 Load Images per Object, not per Scene

### DIFF
--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -12,7 +12,8 @@ import {
   zebraChangeColor,
   jsonDomToWorkspace,
   generateNewDOM,
-  injectNewDom
+  injectNewDom,
+  lazyLoadImage
 } from './utils';
 
 const all_blocks = new Map();
@@ -414,6 +415,9 @@ export class Share {
       'aria-controls': objCollapseOneSceneID
     });
 
+    // attach listener for lazyloading
+    $(cardHeader).on('click', lazyLoadImage);
+
     if (this.config.rtl) {
       cardHeader.style.paddingLeft = '1.5em';
       cardHeader.style.paddingRight = '3.5em';
@@ -628,7 +632,7 @@ export class Share {
         col,
         'img',
         {
-          src: src,
+          'data-src': src,
           class: 'img-fluid catblocks-object-look-item',
           id: imgID,
           'data-toggle': 'modal',

--- a/src/library/js/share/utils.js
+++ b/src/library/js/share/utils.js
@@ -394,3 +394,17 @@ export const changeSceneToRtl = (brick, workspace, sceneWidth) => {
   brick.moveBy(x, y);
   return brick;
 };
+
+/**
+ * Handler for loading images when Object is opened
+ * @param {*} event
+ */
+export const lazyLoadImage = event => {
+  const $objectHeader = $(event.target);
+  $objectHeader.off('click', lazyLoadImage);
+
+  const $contentContainer = $objectHeader.next();
+  $contentContainer.find('img').each(function () {
+    $(this).attr('src', $(this).data('src'));
+  });
+};


### PR DESCRIPTION
Lazy loading of images to save bandwidth (especially on mobile devices)
https://jira.catrob.at/browse/BLOCKS-195


### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
