### PR TITLE
BLOCKS-198 Renderpage - not all programs use lazy loading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}",
             "sourceMapPathOverrides": {
-                "webpack://CatBlocks/./*": "${workspaceFolder}/*"
+                "webpack://CatBlocks/./*": "${workspaceFolder}/*",
+                "webpack:/*": "${workspaceFolder}/*",
+                "webpack://./*": "${workspaceFolder}/*"
             }
         },
         {

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -293,12 +293,7 @@ export class Share {
 
       const $spinnerModal = $('#spinnerModal');
 
-      if (!renderEverything) {
-        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything);
-        continue;
-      }
-
-      if (programJSON.scenes.length === 1) {
+      if (renderEverything || programJSON.scenes.length === 1) {
         this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything);
       } else {
         $('body').on('click', `#${sceneID}`, () => {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-198
`renderEverything` wasn't used properly

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed (Actions)
- [ ] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
