### PR TITLE
BLOCKS-204 Fix Lazy Loading

### DIFF
--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -141,7 +141,8 @@ function getCatroidProgramObject(xml) {
   for (let i = 0; i < scenes.length; i++) {
     sceneList.push(parseScenes(scenes[i]));
   }
-  return { scenes: sceneList };
+  const name = xml.getElementsByTagName('header')[0].getElementsByTagName('programName')[0].innerHTML;
+  return { scenes: sceneList, programName: name };
 }
 /**
  * Flat/dereference xml nodes

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -262,20 +262,13 @@ export class Share {
       const scene = programJSON.scenes[i];
       const sceneID = generateID(`${programID}-${scene.name}`);
 
-      let sceneObjectContainer = undefined;
+      let sceneName = undefined;
       if (programJSON.scenes.length === 1) {
-        sceneObjectContainer = generateNewDOM(scenesContainer, 'div', {
-          class: 'accordion',
-          id: `${sceneID}-accordionObjects`
-        });
+        sceneName = programJSON.programName;
       } else {
-        sceneObjectContainer = this.addSceneContainer(
-          scenesContainerID,
-          sceneID,
-          scenesContainer,
-          trimString(scene.name)
-        );
+        sceneName = trimString(scene.name);
       }
+      const sceneObjectContainer = this.addSceneContainer(scenesContainerID, sceneID, scenesContainer, sceneName);
       if (scene.objectList == null || scene.objectList.length === 0) {
         const errorContainer = generateNewDOM(sceneObjectContainer, 'div', {
           class: 'catblocks-object card'
@@ -298,26 +291,22 @@ export class Share {
         continue;
       }
 
-      if (programJSON.scenes.length === 1) {
-        this.renderAllObjectsFromOneScene(options, scene, programID, sceneID, sceneObjectContainer, renderEverything);
-      } else {
-        $('body').on('click', `#${sceneID}`, () => {
-          if (rendered_scenes[sceneID] !== true) {
-            $spinnerModal.one('shown.bs.modal', () => {
-              this.renderAllObjectsFromOneScene(
-                options,
-                scene,
-                programID,
-                sceneID,
-                sceneObjectContainer,
-                renderEverything
-              );
-              $spinnerModal.modal('hide');
-            });
-            $spinnerModal.modal('show');
-          }
-        });
-      }
+      $('body').on('click', `#${sceneID}`, () => {
+        if (rendered_scenes[sceneID] !== true) {
+          $spinnerModal.one('shown.bs.modal', () => {
+            this.renderAllObjectsFromOneScene(
+              options,
+              scene,
+              programID,
+              sceneID,
+              sceneObjectContainer,
+              renderEverything
+            );
+            $spinnerModal.modal('hide');
+          });
+          $spinnerModal.modal('show');
+        }
+      });
     }
 
     container.appendChild(programContainers[0]);

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -16,7 +16,7 @@ describe('Parser catroid program tests', () => {
     expect(
       await page.evaluate(() => {
         try {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.993</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.993</catrobatLanguageVersion><programName>Test Program</programName></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
           parser.convertProgramToJSONDebug(xmlString);
         } catch (e) {
           if (e.message === 'Found program version 0.993, minimum supported is 0.9994') {
@@ -31,7 +31,7 @@ describe('Parser catroid program tests', () => {
   test('Recognizes supported program version', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion><programName>Test Program</programName></header><scenes><scene><name>игра</name><objectList></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         return (
           programJSON !== undefined &&
@@ -46,7 +46,7 @@ describe('Parser catroid program tests', () => {
   test('Handle empty program properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion><programName>Test Program</programName></header><scenes></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -59,7 +59,7 @@ describe('Parser catroid program tests', () => {
   test('Handle empty single scene properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes><scene><name>tscene</name><objectList></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes><scene><name>tscene</name><objectList></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -77,7 +77,7 @@ describe('Parser catroid program tests', () => {
   test('Handle multiple empty scenes properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes><scene><name>tscene1</name><objectList></objectList></scene><scene><name>tscene2</name><objectList></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.9994</catrobatLanguageVersion></header><scenes><scene><name>tscene1</name><objectList></objectList></scene><scene><name>tscene2</name><objectList></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -97,7 +97,7 @@ describe('Parser catroid program tests', () => {
   test('Handle single empty object properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -117,7 +117,7 @@ describe('Parser catroid program tests', () => {
   test('Handle single empty object in same scene properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -138,7 +138,7 @@ describe('Parser catroid program tests', () => {
   test('Handle single empty object in multiple scenes properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene1</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object></objectList></scene><scene><name>tscene2</name><objectList><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene1</name><objectList><object type="Sprite" name="tobject1"><lookList/><soundList/><scriptList/></object></objectList></scene><scene><name>tscene2</name><objectList><object type="Sprite" name="tobject2"><lookList/><soundList/><scriptList/></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -162,7 +162,7 @@ describe('Parser catroid program tests', () => {
   test('Handle single empty script properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList/></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList/></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -191,7 +191,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Xml Character escaping test', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="цель"><lookList><look fileName="Space-Panda.png" name="цель"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSizeToBrick" id="testBrick"><commentedOut>false</commentedOut><formulaList><formula category="SIZE"><type>NUMBER</type><value id="testValue">60&amp;.0</value></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="цель"><lookList><look fileName="Space-Panda.png" name="цель"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSizeToBrick" id="testBrick"><commentedOut>false</commentedOut><formulaList><formula category="SIZE"><type>NUMBER</type><value id="testValue">60&amp;.0</value></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -205,7 +205,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('LookList reference not within the same object', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestLookListObject"><lookList><look fileName="testLook.png" name="testLook"/></lookList><soundList/><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetLookBrick"><commentedOut>false</commentedOut><look reference="../../../../../../object[1]/lookList/look[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestLookListObject"><lookList><look fileName="testLook.png" name="testLook"/></lookList><soundList/><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetLookBrick"><commentedOut>false</commentedOut><look reference="../../../../../../object[1]/lookList/look[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -221,7 +221,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('SoundList reference not within the same object', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList></lookList><soundList><sound fileName="testSound.png" name="testSound"/></soundList><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSoundBrick"><commentedOut>false</commentedOut><sound reference="../../../../../../object[1]/soundList/sound[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList></lookList><soundList><sound fileName="testSound.png" name="testSound"/></soundList><scriptList/></object><object type="Sprite" name="цель"><lookList></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetSoundBrick"><commentedOut>false</commentedOut><sound reference="../../../../../../object[1]/soundList/sound[1]"/></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -237,7 +237,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Test if no value is used if no nodeValue is given', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList /><soundList><sound fileName="testSound.png" name="testSound" /></soundList><scriptList /></object><object type="Sprite" name="цель"><lookList /><soundList /><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="testFormular"><leftChild><type>NUMBER</type><value>37</value></leftChild><rightChild><type>NUMBER</type><value>58</value></rightChild><type>FUNCTION</type><value /></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>игра</name><objectList><object type="Sprite" name="TestSoundListObject"><lookList /><soundList><sound fileName="testSound.png" name="testSound" /></soundList><scriptList /></object><object type="Sprite" name="цель"><lookList /><soundList /><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="testFormular"><leftChild><type>NUMBER</type><value>37</value></leftChild><rightChild><type>NUMBER</type><value>58</value></rightChild><type>FUNCTION</type><value /></formula></formulaList></brick></brickList><commentedOut>false</commentedOut></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -252,7 +252,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Test if parser converts catroid script properly', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="BroadcastScript"><brickList><brick type="ForeverBrick"><commentedOut>false</commentedOut><loopBricks><brick type="PlaySoundAndWaitBrick"><commentedOut>false</commentedOut><sound name="soundTest"/></brick></loopBricks></brick></brickList><commentedOut>false</commentedOut><receivedMessage>звуки</receivedMessage></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="BroadcastScript"><brickList><brick type="ForeverBrick"><commentedOut>false</commentedOut><loopBricks><brick type="PlaySoundAndWaitBrick"><commentedOut>false</commentedOut><sound name="soundTest"/></brick></loopBricks></brick></brickList><commentedOut>false</commentedOut><receivedMessage>звуки</receivedMessage></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -270,7 +270,7 @@ describe('Catroid to Catblocks parser tests', () => {
   test('Test to check, if the content in the repeat block is right', async () => {
     expect(
       await page.evaluate(() => {
-        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="PlaySoundBrick"><commentedOut>false</commentedOut></brick><brick type="RepeatBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIMES_TO_REPEAT"><type>NUMBER</type><value>1000000000</value></formula></formulaList></brick><brick type="SetBackgroundBrick"></brick><brick type="WaitBrick"></brick><brick type="LoopEndBrick"><commentedOut>false</commentedOut></brick></brickList><commentedOut>false</commentedOut><isUserScript>false</isUserScript></script></scriptList></object></objectList></scene></scenes></program>`;
+        const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="PlaySoundBrick"><commentedOut>false</commentedOut></brick><brick type="RepeatBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIMES_TO_REPEAT"><type>NUMBER</type><value>1000000000</value></formula></formulaList></brick><brick type="SetBackgroundBrick"></brick><brick type="WaitBrick"></brick><brick type="LoopEndBrick"><commentedOut>false</commentedOut></brick></brickList><commentedOut>false</commentedOut><isUserScript>false</isUserScript></script></scriptList></object></objectList></scene></scenes></program>`;
         const programJSON = parser.convertProgramToJSONDebug(xmlString);
         if (programJSON === undefined) {
           return false;
@@ -290,7 +290,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Handle correct spinner value', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>ARDRONE_LED_ANIMATION_BLINK_GREEN_RED</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>ARDRONE_LED_ANIMATION_BLINK_GREEN_RED</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -308,7 +308,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Handle invalid spinner value', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>SOME_VALUE_I_DO_NOT_CARE</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut><ledAnimationName>SOME_VALUE_I_DO_NOT_CARE</ledAnimationName></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -326,7 +326,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Handle non-exiting spinner value', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99995</catrobatLanguageVersion></header><settings/><scenes><scene><name>tscene</name><objectList><object type="Sprite" name="tobject"><lookList/><soundList/><scriptList><script type="tscript"><brickList><brick type="DronePlayLedAnimationBrick"><commentedOut>false</commentedOut></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -345,7 +345,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -374,7 +374,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local empty name uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -403,7 +403,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of local uservariable parsing without name tag', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -432,7 +432,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name>tUserVariable</name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -461,7 +461,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote empty name uservariable parsing', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name></name></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -490,7 +490,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test of remote uservariable parsing without name tag', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable type="UserVariable" serialization="custom"><userVariable><default><deviceValueKey>dcfdd34b-47fb-4fcc-a1cc-97495abf2563</deviceValueKey><name/></default></userVariable></userVariable></brick><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="VARIABLE"><type>NUMBER</type><value>0</value></formula></formulaList><userVariable reference="../../brick[1]"/></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -519,7 +519,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Test if parser handles formula operator properly', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="Y_POSITION"><leftChild><type>NUMBER</type><value>70</value></leftChild><rightChild><type>NUMBER</type><value>90</value></rightChild><type>OPERATOR</type><value>EQUAL</value></formula></formulaList></brick></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetVariableBrick"><commentedOut>false</commentedOut><formulaList><formula category="Y_POSITION"><leftChild><type>NUMBER</type><value>70</value></leftChild><rightChild><type>NUMBER</type><value>90</value></rightChild><type>OPERATOR</type><value>EQUAL</value></formula></formulaList></brick></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -543,7 +543,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Formula with right sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>9</value></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>DIVIDE</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>9</value></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>DIVIDE</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -566,7 +566,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Formula with left sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>2</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>DIVIDE</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>2</value></rightChild><type>OPERATOR</type><value>PLUS</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><type>NUMBER</type><value>8</value></rightChild><type>OPERATOR</type><value>DIVIDE</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -589,7 +589,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Formula with both sided brackets', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><type>NUMBER</type><value>6</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><rightChild><leftChild><type>NUMBER</type><value>1</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></leftChild><rightChild><rightChild><leftChild><type>NUMBER</type><value>5</value></leftChild><rightChild><type>NUMBER</type><value>6</value></rightChild><type>OPERATOR</type><value>MULT</value></rightChild><type>BRACKET</type></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -614,7 +614,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Single value like sqrt function with arithmetic', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>89</value></leftChild><type>FUNCTION</type><value>SQRT</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>89</value></leftChild><type>FUNCTION</type><value>SQRT</value></leftChild><rightChild><type>NUMBER</type><value>5</value></rightChild><type>OPERATOR</type><value>MULT</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -637,7 +637,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Single value like sin function with logic', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>98</value></leftChild><type>FUNCTION</type><value>SIN</value></leftChild><rightChild><type>NUMBER</type><value>32</value></rightChild><type>OPERATOR</type><value>GREATER_THAN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>98</value></leftChild><type>FUNCTION</type><value>SIN</value></leftChild><rightChild><type>NUMBER</type><value>32</value></rightChild><type>OPERATOR</type><value>GREATER_THAN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -660,7 +660,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Two single values like sin plus cos', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>360</value></leftChild><type>FUNCTION</type><value>COS</value></leftChild><rightChild><leftChild><type>NUMBER</type><value>90</value></leftChild><type>FUNCTION</type><value>SIN</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><leftChild><type>NUMBER</type><value>360</value></leftChild><type>FUNCTION</type><value>COS</value></leftChild><rightChild><leftChild><type>NUMBER</type><value>90</value></leftChild><type>FUNCTION</type><value>SIN</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -683,7 +683,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Double value like contains', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetXBrick"><commentedOut>false</commentedOut><formulaList><formula category="X_POSITION"><leftChild><type>NUMBER</type><value>3</value></leftChild><rightChild><type>NUMBER</type><value>1</value></rightChild><type>FUNCTION</type><value>CONTAINS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="SetXBrick"><commentedOut>false</commentedOut><formulaList><formula category="X_POSITION"><leftChild><type>NUMBER</type><value>3</value></leftChild><rightChild><type>NUMBER</type><value>1</value></rightChild><type>FUNCTION</type><value>CONTAINS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -712,7 +712,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('Sensor action in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>SENSOR</type><value>COLLIDES_WITH_FINGER</value></leftChild><rightChild><type>FUNCTION</type><value>TRUE</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>SENSOR</type><value>COLLIDES_WITH_FINGER</value></leftChild><rightChild><type>FUNCTION</type><value>TRUE</value></rightChild><type>OPERATOR</type><value>PLUS</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -735,7 +735,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('UserList in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_LIST</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_LIST</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -758,7 +758,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('UserVariable in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_VARIABLE</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><type>USER_VARIABLE</type><value>tvariable</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;
@@ -781,7 +781,7 @@ describe('Catroid to Catblocks parser tests', () => {
     test('String in formula', async () => {
       expect(
         await page.evaluate(() => {
-          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>STRING</type><value>hello</value></leftChild><rightChild><type>STRING</type><value> world</value></rightChild><type>FUNCTION</type><value>JOIN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
+          const xmlString = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><program><header><programName>Test Program</programName><catrobatLanguageVersion>0.99997</catrobatLanguageVersion></header><scenes><scene><name>TestScene</name><objectList><object type="Sprite" name="TestObject"><lookList><look fileName="Space-Panda.png" name="Space-Panda"/></lookList><soundList/><scriptList><script type="StartScript"><brickList><brick type="WaitBrick"><commentedOut>false</commentedOut><formulaList><formula category="TIME_TO_WAIT_IN_SECONDS"><leftChild><type>STRING</type><value>hello</value></leftChild><rightChild><type>STRING</type><value> world</value></rightChild><type>FUNCTION</type><value>JOIN</value></formula></formulaList></brick></brickList></script></scriptList></object></objectList></scene></scenes></program>`;
           const programJSON = parser.convertProgramToJSONDebug(xmlString);
           if (programJSON === undefined) {
             return false;

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -664,6 +664,7 @@ describe('Share catroid program rendering tests', () => {
     expect(
       await page.evaluate(() => {
         const catObj = {
+          programName: 'testname',
           scenes: [
             {
               name: 'testscene',
@@ -677,9 +678,11 @@ describe('Share catroid program rendering tests', () => {
         };
         share.renderProgramJSON('programID', shareTestContainer, catObj);
 
-        const expectedCardHeaderText =
-          '<div class="header-title">Background</div><i id="code-view-toggler" class="material-icons rotate-left">chevron_left</i>';
-        const cardHeader = shareTestContainer.querySelector('.catblocks-object .card-header');
+        const expectedCardHeaderText = 'testname';
+
+        const cardHeader = shareTestContainer
+          .querySelector('.catblocks-scene .card-header')
+          .querySelector('.header-title');
         const cardHeaderInitialText = cardHeader.innerHTML;
         cardHeader.click();
         cardHeader.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-204
fixed lazy loading for single scene, instead loading scene name the program name is now loaded.
### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
