### PR TITLE
BLOCKS-181 Unify Catblocks and Catroid Brick IDs

### DIFF
--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -37,8 +37,11 @@ class Script {
 }
 
 class Brick {
-  constructor(name) {
+  constructor(name, id) {
     this.name = name;
+    if (id) {
+      this.id = id;
+    }
     this.loopOrIfBrickList = [];
     this.elseBrickList = [];
     this.formValues = new Map();
@@ -535,7 +538,16 @@ function parseBrick(brick) {
 
   const name = (brick.getAttribute('type') || 'emptyBlockName').match(/[a-zA-Z]+/)[0];
 
-  const currentBrick = new Brick(name);
+  let brickId = null;
+  const idTag = brick.getElementsByTagName('brickId');
+  if (idTag && idTag.length >= 1) {
+    brickId = idTag[0].innerHTML;
+    if (brickId) {
+      brickId = brickId.trim();
+    }
+  }
+
+  const currentBrick = new Brick(name, brickId);
 
   for (let i = 0; i < brick.childNodes.length; i++) {
     checkUsage(brick.childNodes[i], currentBrick);


### PR DESCRIPTION
Add brick id to parser to use the same id as Catroid.
https://jira.catrob.at/browse/BLOCKS-181

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
