### PR TITLE
BLOCKS-223 Allow moving bricks or brick blocks

### DIFF
--- a/i18n/catroid_strings/values-en/strings.xml
+++ b/i18n/catroid_strings/values-en/strings.xml
@@ -801,6 +801,7 @@
     <string name="comment_in_out">Disable/enable</string>
     <string name="catblocks">Toggle 2D</string>
     <string name="catblocks_reorder">Clean up scripts</string>
+    <string name="switch_to_1d">1D view</string>
     <!--  -->
 
 

--- a/i18n/strings_to_json_mapping.json
+++ b/i18n/strings_to_json_mapping.json
@@ -555,5 +555,6 @@
   "ASSERTION_TAP_FOR": "${brick_touch_at} ${x_label} %1%2 ${y_label} %3%4 ${brick_tap_for} %5%6",
   "CAST_WHEN_GAMEPAD_BUTTON": "${brick_when_gamepad_button} %1%2 ${brick_when_gamepad_button_tapped}",
   "CLOSE": "${close}",
-  "SHOW_VARIABLE": "${brick_show_variable}"
+  "SHOW_VARIABLE": "${brick_show_variable}",
+  "SWITCH_TO_1D": "${switch_to_1d}"
 }

--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -37,8 +37,11 @@ class Script {
 }
 
 class Brick {
-  constructor(name) {
+  constructor(name, id) {
     this.name = name;
+    if (id) {
+      this.id = id;
+    }
     this.loopOrIfBrickList = [];
     this.elseBrickList = [];
     this.formValues = new Map();
@@ -535,7 +538,16 @@ function parseBrick(brick) {
 
   const name = (brick.getAttribute('type') || 'emptyBlockName').match(/[a-zA-Z]+/)[0];
 
-  const currentBrick = new Brick(name);
+  let brickId = null;
+  const idTag = brick.getElementsByTagName('brickId');
+  if (idTag && idTag.length >= 1) {
+    brickId = idTag[0].innerHTML;
+    if (brickId) {
+      brickId = brickId.trim();
+    }
+  }
+
+  const currentBrick = new Brick(name, brickId);
 
   for (let i = 0; i < brick.childNodes.length; i++) {
     checkUsage(brick.childNodes[i], currentBrick);

--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -164,3 +164,8 @@ img {
   height: 80vh;
   width: 100%;
 }
+
+.catblockls-blockly-invisible > .blocklyPath {
+  fill-opacity: 0;
+  stroke-opacity: 0;
+}

--- a/src/library/js/blocks/bricks.js
+++ b/src/library/js/blocks/bricks.js
@@ -39,7 +39,8 @@ const shapeBricksExtention = () => {
         'WhenBounceOffScript',
         'WhenBackgroundChangesScript',
         'WhenRaspiPinChangedBrick',
-        'UserDefinedScript'
+        'UserDefinedScript',
+        'DummyScript'
       ].includes(blockName)
     ) {
       this.hat = 'cap';

--- a/src/library/js/blocks/categories/dummy.js
+++ b/src/library/js/blocks/categories/dummy.js
@@ -1,0 +1,11 @@
+/**
+ * @description dummy Catblock brick
+ */
+
+'use strict';
+
+export default {
+  DummyScript: {
+    message0: ' '
+  }
+};

--- a/src/library/js/blocks/categories/index.js
+++ b/src/library/js/blocks/categories/index.js
@@ -24,6 +24,7 @@ import sound from './sound';
 import stitch from './stitch';
 import user from './user';
 import device from './device';
+import dummy from './dummy';
 
 export default {
   arduino: arduino,
@@ -44,5 +45,6 @@ export default {
   raspi: raspi,
   sound: sound,
   stitch: stitch,
-  user: user
+  user: user,
+  dummy: dummy
 };

--- a/src/library/js/blocks/colours.js
+++ b/src/library/js/blocks/colours.js
@@ -26,7 +26,8 @@ const colourCodes = {
   sound: { colourPrimary: '#9966FF', colourSecondary: '#6c51b4', colourTertiary: '#774DCB' },
   stitch: { colourPrimary: '#BC4793', colourSecondary: '#bb3a8d', colourTertiary: '#b72a86' },
   user: { colourPrimary: '#bbbbbb', colourSecondary: '#aaaaaa', colourTertiary: '#999999' },
-  default: { colourPrimary: '#34c8a5', colourSecondary: '#299377', colourTertiary: '#238770' }
+  default: { colourPrimary: '#34c8a5', colourSecondary: '#299377', colourTertiary: '#238770' },
+  dummy: { colourPrimary: '#ffffff', colourSecondary: '#ffffff', colourTertiary: '#ffffff' }
 };
 
 /**

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -38,9 +38,6 @@ export class Share {
    */
   async init(options) {
     this.config = parseOptions(options, defaultOptions.render);
-    if (this.config.readOnly) {
-      this.createReadonlyWorkspace();
-    }
     this.generateFormulaModal();
     this.generateModalMagnifyingGlass();
     $('meta[name=viewport]')[0].content = $('meta[name=viewport]')[0].content + ' user-scalable=yes';
@@ -72,6 +69,31 @@ export class Share {
       document.documentElement.style.direction = 'rtl';
     }
     await Blockly.CatblocksMsgs.setLocale(this.config.language, this.config.i18n);
+
+    if (this.config.readOnly) {
+      this.createReadonlyWorkspace();
+    } else {
+      const workspaceItem = {
+        displayText: Blockly.CatblocksMsgs.getCurrentLocaleValues()['SWITCH_TO_1D'],
+        preconditionFn: function () {
+          return 'enabled';
+        },
+        callback: function (scope) {
+          if (scope && scope.block && scope.block.id) {
+            try {
+              Android.switchTo1D(scope.block.id);
+            } catch (error) {
+              console.log(error);
+            }
+          }
+          // console.log(scope);
+        },
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+        id: 'catblocks-switch-to-1d',
+        weight: -5
+      };
+      Blockly.ContextMenuRegistry.registry.register(workspaceItem);
+    }
   }
 
   showFormulaPopup(formula) {

--- a/src/library/js/share/utils.js
+++ b/src/library/js/share/utils.js
@@ -375,6 +375,11 @@ export const renderBrick = (parentBrick, jsonBrick, brickListType, workspace) =>
   }
 
   childBrick.initSvg();
+
+  if (jsonBrick.name == 'DummyScript' && childBrick.pathObject && childBrick.pathObject.svgRoot) {
+    Blockly.utils.dom.addClass(childBrick.pathObject.svgRoot, 'catblockls-blockly-invisible');
+  }
+
   if (brickListType === brickListTypes.brickList) {
     parentBrick.nextConnection.connect(childBrick.previousConnection);
   } else if (brickListType === brickListTypes.elseBrickList || brickListType === brickListTypes.userBrickList) {


### PR DESCRIPTION
Allows to drag & drop bricks in Catblocks.
The position of the moved bricks is saved - each group of bricks has an invisible dummy script brick as parent.
https://jira.catrob.at/browse/BLOCKS-223

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
