### PR TITLE
BLOCKS-223 Allow moving bricks or brick blocks

### DIFF
--- a/i18n/catroid_strings/values-en/strings.xml
+++ b/i18n/catroid_strings/values-en/strings.xml
@@ -801,6 +801,7 @@
     <string name="comment_in_out">Disable/enable</string>
     <string name="catblocks">Toggle 2D</string>
     <string name="catblocks_reorder">Clean up scripts</string>
+    <string name="switch_to_1d">1D view</string>
     <!--  -->
 
 

--- a/i18n/strings_to_json_mapping.json
+++ b/i18n/strings_to_json_mapping.json
@@ -555,5 +555,6 @@
   "ASSERTION_TAP_FOR": "${brick_touch_at} ${x_label} %1%2 ${y_label} %3%4 ${brick_tap_for} %5%6",
   "CAST_WHEN_GAMEPAD_BUTTON": "${brick_when_gamepad_button} %1%2 ${brick_when_gamepad_button_tapped}",
   "CLOSE": "${close}",
-  "SHOW_VARIABLE": "${brick_show_variable}"
+  "SHOW_VARIABLE": "${brick_show_variable}",
+  "SWITCH_TO_1D": "${switch_to_1d}"
 }

--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -37,8 +37,11 @@ class Script {
 }
 
 class Brick {
-  constructor(name) {
+  constructor(name, id) {
     this.name = name;
+    if (id) {
+      this.id = id;
+    }
     this.loopOrIfBrickList = [];
     this.elseBrickList = [];
     this.formValues = new Map();
@@ -535,7 +538,16 @@ function parseBrick(brick) {
 
   const name = (brick.getAttribute('type') || 'emptyBlockName').match(/[a-zA-Z]+/)[0];
 
-  const currentBrick = new Brick(name);
+  let brickId = null;
+  const idTag = brick.getElementsByTagName('brickId');
+  if (idTag && idTag.length >= 1) {
+    brickId = idTag[0].innerHTML;
+    if (brickId) {
+      brickId = brickId.trim();
+    }
+  }
+
+  const currentBrick = new Brick(name, brickId);
 
   for (let i = 0; i < brick.childNodes.length; i++) {
     checkUsage(brick.childNodes[i], currentBrick);

--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -164,3 +164,8 @@ img {
   height: 80vh;
   width: 100%;
 }
+
+.catblockls-blockly-invisible > .blocklyPath {
+  fill-opacity: 0;
+  stroke-opacity: 0;
+}

--- a/src/library/js/blocks/bricks.js
+++ b/src/library/js/blocks/bricks.js
@@ -39,7 +39,8 @@ const shapeBricksExtention = () => {
         'WhenBounceOffScript',
         'WhenBackgroundChangesScript',
         'WhenRaspiPinChangedBrick',
-        'UserDefinedScript'
+        'UserDefinedScript',
+        'EmptyScript'
       ].includes(blockName)
     ) {
       this.hat = 'cap';

--- a/src/library/js/blocks/categories/dummy.js
+++ b/src/library/js/blocks/categories/dummy.js
@@ -1,0 +1,11 @@
+/**
+ * @description dummy Catblock brick
+ */
+
+'use strict';
+
+export default {
+  EmptyScript: {
+    message0: ' '
+  }
+};

--- a/src/library/js/blocks/categories/index.js
+++ b/src/library/js/blocks/categories/index.js
@@ -24,6 +24,7 @@ import sound from './sound';
 import stitch from './stitch';
 import user from './user';
 import device from './device';
+import dummy from './dummy';
 
 export default {
   arduino: arduino,
@@ -44,5 +45,6 @@ export default {
   raspi: raspi,
   sound: sound,
   stitch: stitch,
-  user: user
+  user: user,
+  dummy: dummy
 };

--- a/src/library/js/blocks/colours.js
+++ b/src/library/js/blocks/colours.js
@@ -26,7 +26,8 @@ const colourCodes = {
   sound: { colourPrimary: '#9966FF', colourSecondary: '#6c51b4', colourTertiary: '#774DCB' },
   stitch: { colourPrimary: '#BC4793', colourSecondary: '#bb3a8d', colourTertiary: '#b72a86' },
   user: { colourPrimary: '#bbbbbb', colourSecondary: '#aaaaaa', colourTertiary: '#999999' },
-  default: { colourPrimary: '#34c8a5', colourSecondary: '#299377', colourTertiary: '#238770' }
+  default: { colourPrimary: '#34c8a5', colourSecondary: '#299377', colourTertiary: '#238770' },
+  dummy: { colourPrimary: '#ffffff', colourSecondary: '#ffffff', colourTertiary: '#ffffff' }
 };
 
 /**

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -38,9 +38,6 @@ export class Share {
    */
   async init(options) {
     this.config = parseOptions(options, defaultOptions.render);
-    if (this.config.readOnly) {
-      this.createReadonlyWorkspace();
-    }
     this.generateFormulaModal();
     this.generateModalMagnifyingGlass();
     $('meta[name=viewport]')[0].content = $('meta[name=viewport]')[0].content + ' user-scalable=yes';
@@ -72,6 +69,31 @@ export class Share {
       document.documentElement.style.direction = 'rtl';
     }
     await Blockly.CatblocksMsgs.setLocale(this.config.language, this.config.i18n);
+
+    if (this.config.readOnly) {
+      this.createReadonlyWorkspace();
+    } else {
+      const workspaceItem = {
+        displayText: Blockly.CatblocksMsgs.getCurrentLocaleValues()['SWITCH_TO_1D'],
+        preconditionFn: function () {
+          return 'enabled';
+        },
+        callback: function (scope) {
+          if (scope && scope.block && scope.block.id) {
+            try {
+              Android.switchTo1D(scope.block.id);
+            } catch (error) {
+              console.log(error);
+            }
+          }
+          // console.log(scope);
+        },
+        scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+        id: 'catblocks-switch-to-1d',
+        weight: -5
+      };
+      Blockly.ContextMenuRegistry.registry.register(workspaceItem);
+    }
   }
 
   showFormulaPopup(formula) {

--- a/src/library/js/share/share.js
+++ b/src/library/js/share/share.js
@@ -1000,7 +1000,6 @@ export class Share {
         }
       }
     } else {
-      let initializing = true;
       const scriptContainer = this.generateOrInjectNewDOM(wrapperContainer, 'div', {
         class: 'catblocks-script-modifiable'
       });
@@ -1020,58 +1019,79 @@ export class Share {
           Blockly.svgResize(modifiableWorkspace);
         });
 
-      const topBlocks = modifiableWorkspace.getTopBlocks();
-      let height = 0;
-      for (let i = 0; i < topBlocks.length; ++i) {
-        const topBlock = topBlocks[i];
+      modifiableWorkspace.cleanUp();
+      const topBricks = modifiableWorkspace.getTopBlocks();
+      for (let i = 0; i < topBricks.length; ++i) {
+        const brick = topBricks[i];
+        const script = object.scriptList[i];
 
-        let script_height = topBlock.xy_.y + topBlock.height;
-        let next_block = topBlock.getNextBlock();
-        while (next_block !== null) {
-          script_height += next_block.height;
-          next_block = next_block.getNextBlock();
-        }
+        brick.setMovable(true);
 
-        let x, y;
-        if (
-          object.scriptList[i].posX === undefined ||
-          object.scriptList[i].posY === undefined ||
-          (object.scriptList[i].posX == 0 && object.scriptList[i].posY == 0)
-        ) {
-          if (i == 0) {
-            x = 9.5;
-          } else {
-            x = 10;
-          }
-          y = height;
-        } else {
-          x = object.scriptList[i].posX;
-          y = object.scriptList[i].posY;
+        if (script.posX !== undefined && script.posY !== undefined && (script.posX != 0 || script.posY != 0)) {
+          const position = brick.getRelativeToSurfaceXY();
+          brick.moveBy(Math.round(script.posX - position.x), Math.round(script.posY - position.y));
         }
-        height += script_height + 10;
-        topBlock.setMovable(true);
-        topBlock.moveBy(Math.round(x), Math.round(y));
       }
-      initializing = false;
 
       modifiableWorkspace.addChangeListener(event => {
-        if (initializing) {
-          return;
-        }
-        if (event.type == Blockly.Events.BLOCK_MOVE) {
-          // console.log(event);
-          let isTopBrick = false;
-          const topBlocks = modifiableWorkspace.getTopBlocks();
-          for (let i = 0; i < topBlocks.length; ++i) {
-            if (topBlocks[i].id == event.blockId) {
-              isTopBrick = true;
-              break;
-            }
-          }
+        if (event.type == Blockly.Events.UI && event.element == 'dragStop') {
+          const droppedBrick = modifiableWorkspace.getBlockById(event.blockId);
+          const isTopBrick = droppedBrick.hat !== undefined;
+          const position = droppedBrick.getRelativeToSurfaceXY();
 
-          if (isTopBrick === true && event.oldParentId === undefined && event.newParentId === undefined) {
-            // move of top (script) brick
-            Android.updateScriptPosition(event.blockId, event.newCoordinate.x, event.newCoordinate.y);
+          if (isTopBrick) {
+            Android.updateScriptPosition(event.blockId, position.x, position.y);
+          } else {
+            const bricksToMove = [];
+            for (let i = 0; i < event.oldValue.length; ++i) {
+              bricksToMove.push(event.oldValue[i].id);
+            }
+
+            if (droppedBrick.getParent() == undefined) {
+              const newEmptyBrickId = Android.moveBricksToEmptyScriptBrick(bricksToMove);
+              const newBrick = modifiableWorkspace.newBlock('EmptyScript', newEmptyBrickId);
+              newBrick.initSvg();
+              newBrick.moveBy(position.x, position.y);
+              newBrick.nextConnection.connect(droppedBrick.previousConnection);
+              newBrick.render();
+              droppedBrick.setParent(newBrick);
+              Android.updateScriptPosition(newEmptyBrickId, position.x, position.y);
+
+              if (newBrick.pathObject && newBrick.pathObject.svgRoot) {
+                Blockly.utils.dom.addClass(newBrick.pathObject.svgRoot, 'catblockls-blockly-invisible');
+              }
+
+              const idsToRemove = Android.removeEmptyScriptBricks();
+              this.removeEmptyScriptBricksById(modifiableWorkspace, idsToRemove);
+            } else {
+              // console.log(droppedBrick);
+              // console.log(droppedBrick.getTopStackBlock());
+
+              const firstBrickInStack = droppedBrick.getTopStackBlock();
+              const isFirstBrickInStack = firstBrickInStack.id.toLowerCase() == droppedBrick.id.toLowerCase();
+
+              let subStackIdx = -1;
+              if (
+                isFirstBrickInStack &&
+                firstBrickInStack &&
+                firstBrickInStack.getParent() &&
+                firstBrickInStack.getParent().inputList &&
+                firstBrickInStack.getParent().inputList.length > 0
+              ) {
+                const subStacks = firstBrickInStack.getParent().inputList.filter(x => x.type == 3);
+                for (let i = 0; i < subStacks.length; ++i) {
+                  if (subStacks[i].connection.targetConnection) {
+                    if (subStacks[i].connection.targetConnection.sourceBlock_.id == firstBrickInStack.id) {
+                      subStackIdx = i;
+                      break;
+                    }
+                  }
+                }
+              }
+              Android.moveBricks(droppedBrick.getParent().id, subStackIdx, bricksToMove);
+              const idsToRemove = Android.removeEmptyScriptBricks();
+              this.removeEmptyScriptBricksById(modifiableWorkspace, idsToRemove);
+            }
           }
         }
       });
@@ -1091,6 +1111,23 @@ export class Share {
       );
     }
     return modifiableWorkspace;
+  }
+
+  removeEmptyScriptBricksById(workspace, strBrickIDs) {
+    try {
+      const brickIDs = JSON.parse(strBrickIDs);
+      if (brickIDs) {
+        for (let i = 0; i < brickIDs.length; ++i) {
+          const brickToRemove = workspace.blockDB_[brickIDs[i]];
+          if (brickToRemove) {
+            workspace.removeBlockById(brickIDs[i]);
+            brickToRemove.dispose(false);
+          }
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
   }
 
   /**
@@ -1245,6 +1282,11 @@ export class Share {
     if (sceneWorkspaces) {
       const objectsWorkspace = sceneWorkspaces[object];
       objectsWorkspace.cleanUp();
+
+      const topBricks = objectsWorkspace.getTopBlocks();
+      for (let i = 0; i < topBricks.length; ++i) {
+        Android.updateScriptPosition(topBricks[i].id, 0, 0);
+      }
     }
   }
 }

--- a/src/library/js/share/utils.js
+++ b/src/library/js/share/utils.js
@@ -375,6 +375,11 @@ export const renderBrick = (parentBrick, jsonBrick, brickListType, workspace) =>
   }
 
   childBrick.initSvg();
+
+  if (jsonBrick.name == 'EmptyScript' && childBrick.pathObject && childBrick.pathObject.svgRoot) {
+    Blockly.utils.dom.addClass(childBrick.pathObject.svgRoot, 'catblockls-blockly-invisible');
+  }
+
   if (brickListType === brickListTypes.brickList) {
     parentBrick.nextConnection.connect(childBrick.previousConnection);
   } else if (brickListType === brickListTypes.elseBrickList || brickListType === brickListTypes.userBrickList) {

--- a/test/jsunit/block/block.test.js
+++ b/test/jsunit/block/block.test.js
@@ -33,6 +33,11 @@ describe('Filesystem Block tests', () => {
       Object.keys(BLOCKS[categoryName]).forEach(blockName => {
         const block = BLOCKS[categoryName][blockName];
         const blockMsg = block.message0;
+
+        if (blockName == 'EmptyScript') {
+          return blockMsg == ' ';
+        }
+
         const blockMsgName = blockMsg.substring(6, blockMsg.length - 1);
         // verify if it exists
         expect(BLOCK_MSG_MAPPINGS[blockMsgName]).not.toBeUndefined();
@@ -62,6 +67,11 @@ describe('Filesystem Block tests', () => {
       Object.keys(BLOCKS[categoryName]).forEach(blockName => {
         const block = BLOCKS[categoryName][blockName];
         const blockMsg = block.message0;
+
+        if (blockName == 'EmptyScript') {
+          return blockMsg == ' ';
+        }
+
         const blockMsgName = blockMsg.substring(6, blockMsg.length - 1);
 
         const defArgs = Object.keys(block).filter(key => {
@@ -297,52 +307,56 @@ describe('WebView Block tests', () => {
           let returnStatus = true;
           Object.keys(BLOCKS).forEach(categoryName => {
             Object.keys(BLOCKS[categoryName]).forEach(blockName => {
-              const jsBlock = BLOCKS[categoryName][blockName];
-              const renderedBlock = allRenderedBlocks[indexOfBlock].svgGroup_.querySelectorAll('g.blocklyEditableText');
-              //get args from js-files (in blocks/categories directory)
-              const allJsArguments = [];
-              if (jsBlock['args0'] !== undefined) {
-                let jsBlockIndex = 0;
-                while (jsBlock['args0'][jsBlockIndex] !== undefined) {
-                  if (jsBlock['args0'][jsBlockIndex]['value'] !== undefined) {
-                    allJsArguments.push(jsBlock['args0'][jsBlockIndex]['value']);
+              if (blockName != 'EmptyScript') {
+                const jsBlock = BLOCKS[categoryName][blockName];
+                const renderedBlock = allRenderedBlocks[indexOfBlock].svgGroup_.querySelectorAll(
+                  'g.blocklyEditableText'
+                );
+                //get args from js-files (in blocks/categories directory)
+                const allJsArguments = [];
+                if (jsBlock['args0'] !== undefined) {
+                  let jsBlockIndex = 0;
+                  while (jsBlock['args0'][jsBlockIndex] !== undefined) {
+                    if (jsBlock['args0'][jsBlockIndex]['value'] !== undefined) {
+                      allJsArguments.push(jsBlock['args0'][jsBlockIndex]['value']);
+                    }
+                    if (jsBlock['args0'][jsBlockIndex]['text'] !== undefined) {
+                      allJsArguments.push(jsBlock['args0'][jsBlockIndex]['text']);
+                    }
+                    if (jsBlock['args0'][jsBlockIndex]['options'] !== undefined) {
+                      allJsArguments.push(jsBlock['args0'][jsBlockIndex]['options'][0][0]);
+                    }
+                    jsBlockIndex++;
                   }
-                  if (jsBlock['args0'][jsBlockIndex]['text'] !== undefined) {
-                    allJsArguments.push(jsBlock['args0'][jsBlockIndex]['text']);
-                  }
-                  if (jsBlock['args0'][jsBlockIndex]['options'] !== undefined) {
-                    allJsArguments.push(jsBlock['args0'][jsBlockIndex]['options'][0][0]);
-                  }
-                  jsBlockIndex++;
                 }
-              }
-              if (jsBlock['args2'] !== undefined) {
-                let jsBlockIndex = 0;
-                while (jsBlock['args2'][jsBlockIndex] !== undefined) {
-                  if (jsBlock['args2'][jsBlockIndex]['value'] !== undefined) {
-                    allJsArguments.push(jsBlock['args2'][jsBlockIndex]['value']);
+                if (jsBlock['args2'] !== undefined) {
+                  let jsBlockIndex = 0;
+                  while (jsBlock['args2'][jsBlockIndex] !== undefined) {
+                    if (jsBlock['args2'][jsBlockIndex]['value'] !== undefined) {
+                      allJsArguments.push(jsBlock['args2'][jsBlockIndex]['value']);
+                    }
+                    if (jsBlock['args2'][jsBlockIndex]['text'] !== undefined) {
+                      allJsArguments.push(jsBlock['args2'][jsBlockIndex]['text']);
+                    }
+                    if (jsBlock['args2'][jsBlockIndex]['options'] !== undefined) {
+                      allJsArguments.push(jsBlock['args2'][jsBlockIndex]['options'][0][0]);
+                    }
+                    jsBlockIndex++;
                   }
-                  if (jsBlock['args2'][jsBlockIndex]['text'] !== undefined) {
-                    allJsArguments.push(jsBlock['args2'][jsBlockIndex]['text']);
-                  }
-                  if (jsBlock['args2'][jsBlockIndex]['options'] !== undefined) {
-                    allJsArguments.push(jsBlock['args2'][jsBlockIndex]['options'][0][0]);
-                  }
-                  jsBlockIndex++;
                 }
-              }
-              if (allJsArguments.length !== renderedBlock.length) {
-                returnStatus = false;
-              }
-              //check if rendered arguments and js arguments are equal
-              for (let argIndex = 0; argIndex < renderedBlock.length; argIndex++) {
-                const jsArgument = allJsArguments[argIndex].toString().trim().replace(/\s/g, ' ');
-                const renderedArgument = renderedBlock[argIndex].textContent.trim().replace(/\s/g, ' ');
-                if (jsArgument !== renderedArgument) {
+                if (allJsArguments.length !== renderedBlock.length) {
                   returnStatus = false;
                 }
+                //check if rendered arguments and js arguments are equal
+                for (let argIndex = 0; argIndex < renderedBlock.length; argIndex++) {
+                  const jsArgument = allJsArguments[argIndex].toString().trim().replace(/\s/g, ' ');
+                  const renderedArgument = renderedBlock[argIndex].textContent.trim().replace(/\s/g, ' ');
+                  if (jsArgument !== renderedArgument) {
+                    returnStatus = false;
+                  }
+                }
+                indexOfBlock++;
               }
-              indexOfBlock++;
             });
           });
           return returnStatus;


### PR DESCRIPTION
Allows to drag & drop bricks in Catblocks.
The position of the moved bricks is saved - each group of bricks has an invisible dummy script brick as parent.
https://jira.catrob.at/browse/BLOCKS-223

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
