### PR TITLE
BLOCKS-232 Disabled bricks displayed wrong

### DIFF
--- a/src/common/js/parser/parser.js
+++ b/src/common/js/parser/parser.js
@@ -26,12 +26,13 @@ class File {
 }
 
 class Script {
-  constructor(name, id, posX, posY) {
+  constructor(name, id, posX, posY, commentedOut) {
     this.name = name;
     this.brickList = [];
     this.posX = posX;
     this.posY = posY;
     this.id = id;
+    this.commentedOut = commentedOut;
     this.formValues = new Map();
   }
 }
@@ -44,6 +45,7 @@ class Brick {
     this.formValues = new Map();
     this.colorVariation = 0;
     this.userBrickId = undefined;
+    this.commentedOut = false;
   }
 }
 
@@ -315,7 +317,14 @@ function parseScripts(script) {
   if (scriptIdTag.length > 0) {
     scriptId = scriptIdTag[0].innerHTML;
   }
-  const currentScript = new Script(name, scriptId, posX, posY);
+
+  let commentedOut = false;
+  const commentedOutTag = script.getElementsByTagName('commentedOut');
+  if (commentedOutTag.length > 0) {
+    commentedOut = commentedOutTag[0].innerHTML == 'true';
+  }
+
+  const currentScript = new Script(name, scriptId, posX, posY, commentedOut);
   const brickList = script.getElementsByTagName('brickList')[0].children;
   for (let i = 0; i < script.childNodes.length; i++) {
     checkUsage(script.childNodes[i], currentScript);
@@ -694,6 +703,11 @@ function checkUsage(list, location) {
 
     case 'userDefinedBrickID': {
       location.userBrickId = list.innerHTML;
+      break;
+    }
+
+    case 'commentedOut': {
+      location.commentedOut = list.innerHTML == 'true';
       break;
     }
 

--- a/src/library/css/share.css
+++ b/src/library/css/share.css
@@ -164,3 +164,8 @@ img {
   height: 80vh;
   width: 100%;
 }
+
+.catblocks-blockly-disabled > .blocklyPath {
+  fill-opacity: 0.5;
+  stroke-opacity: 0.5;
+}

--- a/src/library/js/share/utils.js
+++ b/src/library/js/share/utils.js
@@ -375,6 +375,11 @@ export const renderBrick = (parentBrick, jsonBrick, brickListType, workspace) =>
   }
 
   childBrick.initSvg();
+
+  if (jsonBrick.commentedOut && childBrick.pathObject && childBrick.pathObject.svgRoot) {
+    Blockly.utils.dom.addClass(childBrick.pathObject.svgRoot, 'catblocks-blockly-disabled');
+  }
+
   if (brickListType === brickListTypes.brickList) {
     parentBrick.nextConnection.connect(childBrick.previousConnection);
   } else if (brickListType === brickListTypes.elseBrickList || brickListType === brickListTypes.userBrickList) {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-232
Disabled bricks are displayed with 50% opacity now.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
