### PR TITLE
BLOCKS-207 Do not show any trailing 0 after the dot in rational numbers

### DIFF
--- a/src/common/js/parser/formula.js
+++ b/src/common/js/parser/formula.js
@@ -79,7 +79,8 @@ export default class Formula {
   static packValue(layout, key, value) {
     if (['%v', '%l', '%r'].includes(key)) {
       if (value.length > 0) {
-        return layout.replace(key, `${value.trim()}`);
+        const result = value.replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
+        return layout.replace(key, `${result.trim()}`);
       }
       return layout.replace(key, '').trim();
     }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -197,7 +197,7 @@ describe('Catroid to Catblocks parser tests', () => {
           return false;
         }
         const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-        return formulaMap !== undefined && formulaMap.entries().next().value.toString().includes('60&.0');
+        return formulaMap !== undefined && formulaMap.entries().next().value.toString().includes('60&');
       })
     ).toBeTruthy();
   });


### PR DESCRIPTION
remove trailing zeros from bricks.
https://jira.catrob.at/browse/BLOCKS-207

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
