### PR TITLE
Blocks 237 Spaces at beginning and end of strings not shown

### DIFF
--- a/src/common/js/parser/formula.js
+++ b/src/common/js/parser/formula.js
@@ -80,9 +80,9 @@ export default class Formula {
     if (['%v', '%l', '%r'].includes(key)) {
       if (value.length > 0) {
         const result = value.replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
-        return layout.replace(key, `${result.trim()}`);
+        return layout.replace(key, `${result}`);
       }
-      return layout.replace(key, '').trim();
+      return layout.replace(key, '');
     }
     return layout;
   }

--- a/src/common/js/parser/formula.js
+++ b/src/common/js/parser/formula.js
@@ -79,7 +79,8 @@ export default class Formula {
   static packValue(layout, key, value) {
     if (['%v', '%l', '%r'].includes(key)) {
       if (value.length > 0) {
-        return layout.replace(key, `${value.trim()}`);
+        const result = value.replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
+        return layout.replace(key, `${result.trim()}`);
       }
       return layout.replace(key, '').trim();
     }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -244,7 +244,7 @@ describe('Catroid to Catblocks parser tests', () => {
         }
         const brickName = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].name;
         const formulaMap = programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].formValues;
-        return brickName === 'WaitBrick' && formulaMap.entries().next().value.toString().includes('37  58');
+        return brickName === 'WaitBrick' && formulaMap.entries().next().value.toString().includes('37    58');
       })
     ).toBeTruthy();
   });
@@ -362,7 +362,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1] === 'tUserVariable' &&
             block === 'SetVariableBrick'
@@ -391,7 +391,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -420,7 +420,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -449,7 +449,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1] === 'tUserVariable' &&
             block === 'SetVariableBrick'
@@ -478,7 +478,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -507,7 +507,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === '0' &&
+            mapValues[0] === (' 0 ') &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -526,13 +526,13 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'SetVariableBrick' &&
             firstMapKey === 'Y_POSITION' &&
-            firstMapValue === '70 = 90'
+            firstMapValue === ' 70  =  90 '
           );
         })
       ).toBeTruthy();
@@ -550,9 +550,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = '1 × (5 ÷ (9 + 8))'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = ' 1  × ( 5  ÷ ( 9  +  8 ))';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -573,9 +573,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = '((1 + 2) × 8) ÷ 8'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = '(( 1  +  2 ) ×  8 ) ÷  8 ';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -596,9 +596,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = '(1 × 5) + (5 × 6)'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = '( 1  ×  5 ) + ( 5  ×  6 )';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -621,9 +621,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = 'square root(89) × 5'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = 'square root( 89 ) ×  5 ';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -644,9 +644,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = 'sine(98) > 32'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = 'sine( 98 ) >  32 ';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -667,9 +667,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = 'cosine(360) + sine(90)'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = 'cosine( 360 ) + sine( 90 )';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -690,15 +690,14 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = 'contains(3, 1)'.trim();
+          const refString = 'contains( 3 ,  1 )';
           const splitIndex = formulaMap.entries().next().value.toString().indexOf(',');
-          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex).trim();
+          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex);
           const firstMapValue = formulaMap
             .entries()
             .next()
             .value.toString()
-            .slice(splitIndex + 1)
-            .trim();
+            .slice(splitIndex + 1);
           return (
             formulaMap.size === 1 &&
             block === 'SetXBrick' &&
@@ -719,9 +718,9 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = 'touches finger + true'.trim();
-          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0].trim();
-          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1].trim();
+          const refString = ' touches finger  +  true ';
+          const firstMapKey = formulaMap.entries().next().value.toString().split(',')[0];
+          const firstMapValue = formulaMap.entries().next().value.toString().split(',')[1];
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&
@@ -788,15 +787,14 @@ describe('Catroid to Catblocks parser tests', () => {
           }
           const block = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].name;
           const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-          const refString = "join('hello', 'world')".trim();
+          const refString = "join('hello', ' world')";
           const splitIndex = formulaMap.entries().next().value.toString().indexOf(',');
-          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex).trim();
+          const firstMapKey = formulaMap.entries().next().value.toString().slice(0, splitIndex);
           const firstMapValue = formulaMap
             .entries()
             .next()
             .value.toString()
-            .slice(splitIndex + 1)
-            .trim();
+            .slice(splitIndex + 1);
           return (
             formulaMap.size === 1 &&
             block === 'WaitBrick' &&

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -362,7 +362,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1] === 'tUserVariable' &&
             block === 'SetVariableBrick'
@@ -391,7 +391,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -420,7 +420,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -449,7 +449,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1] === 'tUserVariable' &&
             block === 'SetVariableBrick'
@@ -478,7 +478,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'
@@ -507,7 +507,7 @@ describe('Catroid to Catblocks parser tests', () => {
             mapKeys.length === 2 &&
             mapValues.length === 2 &&
             mapKeys[0] === 'VARIABLE' &&
-            mapValues[0] === (' 0 ') &&
+            mapValues[0] === ' 0 ' &&
             mapKeys[1] === 'DROPDOWN' &&
             mapValues[1].length === 0 &&
             block === 'SetVariableBrick'

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -197,7 +197,7 @@ describe('Catroid to Catblocks parser tests', () => {
           return false;
         }
         const formulaMap = programJSON.scenes[0].objectList[0].scriptList[0].brickList[0].formValues;
-        return formulaMap !== undefined && formulaMap.entries().next().value.toString().includes('60&.0');
+        return formulaMap !== undefined && formulaMap.entries().next().value.toString().includes('60&');
       })
     ).toBeTruthy();
   });


### PR DESCRIPTION
Spaces at beginning and end are now shown correctly.
https://jira.catrob.at/browse/BLOCKS-237

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
