### PR TITLE
BLOCKS-241 Improve dropping bricks in Catroid

### DIFF
--- a/src/library/js/integration/catroid.js
+++ b/src/library/js/integration/catroid.js
@@ -170,16 +170,23 @@ export class Catroid {
 
           if (droppedBrick.getParent() == undefined) {
             const newEmptyBrickId = Android.moveBricksToEmptyScriptBrick(bricksToMove);
-            const newBrick = this.workspace.newBlock('EmptyScript', newEmptyBrickId);
-            newBrick.initSvg();
-            newBrick.moveBy(position.x, position.y);
-            newBrick.nextConnection.connect(droppedBrick.previousConnection);
-            newBrick.render();
-            droppedBrick.setParent(newBrick);
-            Android.updateScriptPosition(newEmptyBrickId, position.x, position.y);
+            const newEmptyBrick = this.workspace.newBlock('EmptyScript', newEmptyBrickId);
+            newEmptyBrick.initSvg();
+            newEmptyBrick.render();
 
-            if (newBrick.pathObject && newBrick.pathObject.svgRoot) {
-              Blockly.utils.dom.addClass(newBrick.pathObject.svgRoot, 'catblockls-blockly-invisible');
+            const newEmptyBrickSize = newEmptyBrick.getHeightWidth();
+            const connectionOffset = 8;
+            const newEmptyBrickPositionX = position.x;
+            const newEmptyBrickPositionY = position.y - newEmptyBrickSize.height + connectionOffset;
+            newEmptyBrick.moveBy(newEmptyBrickPositionX, newEmptyBrickPositionY);
+
+            newEmptyBrick.nextConnection.connect(droppedBrick.previousConnection);
+            droppedBrick.setParent(newEmptyBrick);
+
+            Android.updateScriptPosition(newEmptyBrickId, newEmptyBrickPositionX, newEmptyBrickPositionY);
+
+            if (newEmptyBrick.pathObject && newEmptyBrick.pathObject.svgRoot) {
+              Blockly.utils.dom.addClass(newEmptyBrick.pathObject.svgRoot, 'catblockls-blockly-invisible');
             }
             this.removeEmptyScriptBricks();
           } else {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-241
When dropping a brick, the brick jumped down after adding the invisible brick. This jump is now removed.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
