### PR TITLE
BLOCKS-237 Spaces at beginning and end of strings not shown

### DIFF
--- a/src/common/js/parser/formula.js
+++ b/src/common/js/parser/formula.js
@@ -80,9 +80,9 @@ export default class Formula {
     if (['%v', '%l', '%r'].includes(key)) {
       if (value.length > 0) {
         const result = value.replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
-        return layout.replace(key, `${result.trim()}`);
+        return layout.replace(key, `${result}`);
       }
-      return layout.replace(key, '').trim();
+      return layout.replace(key, '');
     }
     return layout;
   }

--- a/test/jsunit/parser/parser.test.js
+++ b/test/jsunit/parser/parser.test.js
@@ -432,7 +432,7 @@ describe('Catroid to Catblocks parser tests', () => {
       return formulaMap.entries().next().value.toString();
     }, xmlString);
 
-    expect(formula).toMatch('SIZE,60&');
+    expect(formula).toMatch('SIZE, 60& ');
   });
 
   test('LookList reference not within the same object', async () => {
@@ -629,7 +629,7 @@ describe('Catroid to Catblocks parser tests', () => {
     }, xmlString);
 
     expect(programJSON.scenes[0].objectList[1].scriptList[0].brickList[0].name).toBe(brickName);
-    expect(formulaString).toMatch(`${val1}  ${val2}`);
+    expect(formulaString).toMatch(`${val1}    ${val2}`);
   });
 
   test('Test if parser converts catroid script properly', async () => {
@@ -1069,7 +1069,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, userVarialbe]);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', userVarialbe]);
     });
 
     test('Test of local empty name uservariable parsing', async () => {
@@ -1158,7 +1158,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, '']);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', '']);
     });
 
     test('Test of local uservariable parsing without name tag', async () => {
@@ -1247,7 +1247,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, '']);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', '']);
     });
 
     test('Test of remote uservariable parsing', async () => {
@@ -1348,7 +1348,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, userVariable]);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', userVariable]);
     });
 
     test('Test of remote empty name uservariable parsing', async () => {
@@ -1448,7 +1448,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, '']);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', '']);
     });
 
     test('Test of remote uservariable parsing without name tag', async () => {
@@ -1548,7 +1548,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName, 'DROPDOWN']);
-      expect(mapValues).toEqual([firstValue, '']);
+      expect(mapValues).toEqual([' ' + firstValue + ' ', '']);
     });
 
     test('Test if parser handles formula operator properly', async () => {
@@ -1639,7 +1639,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([variableName]);
-      expect(mapValues).toEqual([`${firstValue} = ${secondValue}`]);
+      expect(mapValues).toEqual([` ${firstValue}  =  ${secondValue} `]);
     });
   });
 
@@ -1756,7 +1756,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`${first} × (${second} ÷ (${third} + ${fourth}))`]);
+      expect(mapValues).toEqual([` ${first}  × ( ${second}  ÷ ( ${third}  +  ${fourth} ))`]);
     });
 
     test('Formula with left sided brackets', async () => {
@@ -1871,7 +1871,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`((${first} + ${second}) × ${third}) ÷ ${fourth}`]);
+      expect(mapValues).toEqual([`(( ${first}  +  ${second} ) ×  ${third} ) ÷  ${fourth} `]);
     });
 
     test('Formula with both sided brackets', async () => {
@@ -1986,7 +1986,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`(${first} × ${second}) + (${third} × ${fourth})`]);
+      expect(mapValues).toEqual([`( ${first}  ×  ${second} ) + ( ${third}  ×  ${fourth} )`]);
     });
   });
 
@@ -2083,7 +2083,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`square root(${first}) × ${second}`]);
+      expect(mapValues).toEqual([`square root( ${first} ) ×  ${second} `]);
     });
 
     test('Single value like sin function with logic', async () => {
@@ -2178,7 +2178,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`sine(${first}) > ${second}`]);
+      expect(mapValues).toEqual([`sine( ${first} ) >  ${second} `]);
     });
 
     test('Two single values like sin plus cos', async () => {
@@ -2277,7 +2277,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`cosine(${first}) + sine(${second})`]);
+      expect(mapValues).toEqual([`cosine( ${first} ) + sine( ${second} )`]);
     });
 
     test('Double value like contains', async () => {
@@ -2368,7 +2368,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`contains(${first}, ${second})`]);
+      expect(mapValues).toEqual([`contains( ${first} ,  ${second} )`]);
     });
 
     test('Sensor action in formula', async () => {
@@ -2457,7 +2457,7 @@ describe('Catroid to Catblocks parser tests', () => {
       );
 
       expect(mapKeys).toEqual([categoryName]);
-      expect(mapValues).toEqual([`touches finger + true`]);
+      expect(mapValues).toEqual([` touches finger  +  true `]);
     });
 
     test('UserList in formula', async () => {


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*
https://jira.catrob.at/browse/BLOCKS-237
Spaces at beginning and end are no longer be trimmed.
### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
