### PR TITLE
BLOCKS-258 Do not show "\" to users (unless the user typed it in)

### DIFF
--- a/i18n/catroid_strings/values-af/strings.xml
+++ b/i18n/catroid_strings/values-af/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-az/strings.xml
+++ b/i18n/catroid_strings/values-az/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Ayarlar</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Adını dəyiş</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Bel çantası</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-bg/strings.xml
+++ b/i18n/catroid_strings/values-bg/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-bn/strings.xml
+++ b/i18n/catroid_strings/values-bn/strings.xml
@@ -878,7 +878,7 @@
     <string name="brick_speak_default_value">হ্যালো</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">এবং অপেক্ষা করুন</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1546,7 +1546,7 @@
     <string name="formula_editor_function_list_item_parameter">(১, * তালিকার নাম *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">ধারণ করে</string>
     <string name="formula_editor_function_contains_parameter">(* তালিকার নাম *,১)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(১, * তালিকার নাম *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">আইটেমের সংখ্যা</string>
     <string name="formula_editor_function_number_of_items_parameter">(* তালিকার নাম *)</string>
@@ -1783,7 +1783,7 @@
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">আপনার প্রজেক্টি অ্যাপ্লিকেশনটির শেয়ার করে নেওয়ার সাইটে আপলোড হবে যেখানে অন্যরা এটি ব্যবহার এবং ডাউনলোড করতে পারে। আপনি নিজের প্রজেক্টি একটি স্বতন্ত্র অ্যাপ্লিকেশন হিসাবে ডাউনলোড করতে পারেন।</string>
     <string name="progress_upload_dialog_failed">আপলোড ব্যর্থ হয়েছে। আপনার সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।</string>

--- a/i18n/catroid_strings/values-bs/strings.xml
+++ b/i18n/catroid_strings/values-bs/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Veliki tekst</string>
     <string name="preference_title_accessibility_element_spacing">Veliki razmak elemenata</string>
     <string name="preference_description_accessibility_element_spacing">Povećajte razmak elemenata u listama.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop kašnjenje</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop kašnjenje za cigle.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop kašnjenje</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop kašnjenje za cigle.</string>
     <string name="preference_title_accessibility_beginner_bricks">Početnički mod</string>
     <string name="preference_description_accessibility_beginner_bricks">Prikaži samo jednostavne stavke.</string>
     <string name="preference_title_accessibility_font_style">Izaberi tip teksta</string>
@@ -156,7 +156,7 @@
     <string name="preference_access_title_profile_odin">Odin</string>
     <string name="preference_access_summary_profile_odin">Veliki tekst, velike ikone, veliki razmak elemenata, visoki kontrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Veliki razmak elemenata, drag\'n\'drop usporavanje</string>
+    <string name="preference_access_summary_profile_fenrir">Veliki razmak elemenata, drag'n'drop usporavanje</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Početnički mod</string>
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
@@ -930,7 +930,7 @@
     <string name="brick_speak_default_value">Zdravo!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">i čekajte</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1232,9 +1232,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Nešto je pošlo po zlu pri postavljanju projekta.</string>
     <string name="error_project_download">Došlo je do greške prilikom preuzimanja programa.</string>
@@ -1265,7 +1265,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_unsupported_bricks_chromecast">Ova skripta ne može biti dodana u Chromecast projekat.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Upareni uređaji</string>
     <string name="title_other_devices">Novi uređaji</string>
     <string name="searching_devices">Traženje uređaja&#8230;</string>
@@ -1609,7 +1609,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*naziv liste*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">sadrži</string>
     <string name="formula_editor_function_contains_parameter">(*naziv liste*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*naziv liste*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">broj stvari</string>
     <string name="formula_editor_function_number_of_items_parameter">(*naziv liste*)</string>
@@ -1849,14 +1849,14 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Traženje Chromecast uređaja</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Veza istekla. Molimo Vas da pokušate ponovo.</string>
     <string name="cast_screen_pause_text">Pauzirano</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Vaš projekat će se objaviti na stranici za dijeljenje gdje ga ostali mogu koristiti i preuzeti. Također možete preuzeti Vaš projekat kao samostalnu aplikaciju.</string>
     <string name="progress_upload_dialog_failed">Preuzimanje neuspješno. Molimo da provjerite Vašu internet konekciju i pokušate ponovo!</string>

--- a/i18n/catroid_strings/values-ca/strings.xml
+++ b/i18n/catroid_strings/values-ca/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Escull un tipus de font</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Canvia el nom</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Motxilla</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-chr/strings.xml
+++ b/i18n/catroid_strings/values-chr/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-cs/strings.xml
+++ b/i18n/catroid_strings/values-cs/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Velké písmo</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop zpoždění</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop zpoždění pro bloky.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop zpoždění</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop zpoždění pro bloky.</string>
     <string name="preference_title_accessibility_beginner_bricks">Začátečnické bloky</string>
     <string name="preference_description_accessibility_beginner_bricks">Zobrazuje pouze základní bloky.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Začátečnické bloky</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone bloky</string>
     <string name="preference_description_quadcopter_bricks">Povolit aplikaci ovládat AR.Drone 2.0 kvadrakoptéry</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo bloky</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">LEGO Mindstorms NXT bloky</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">LEGO Mindstorms EV3 kostky</string>
     <string name="preference_description_mindstorms_nxt_bricks">Umožnit aplikaci ovládat roboty z Lego Mindstorms NXT</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">Senzory LEGO EV3</string>
     <string name="preference_title_drone_config_properties">Konfigurace AR.Drone 2.0</string>
     <string name="preference_title_enable_phiro_bricks">Phiro bloky</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino bloky</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -981,7 +981,7 @@
     <string name="brick_speak_default_value">Ahoj!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">a počkat</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1288,9 +1288,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Došlo k chybě při nahrávání programu.</string>
     <string name="error_project_download">Došlo k chybě při stahování programu.</string>
@@ -1320,11 +1320,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Spárovaná zařízení</string>
     <string name="title_other_devices">Nová zařízení</string>
     <string name="searching_devices">Vyhledávání zařízení&#8230;</string>
@@ -1669,7 +1669,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1, * jméno seznamu *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">obsahuje</string>
     <string name="formula_editor_function_contains_parameter">(* jméno seznamu *, 1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, * jméno seznamu *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">počet_položek</string>
     <string name="formula_editor_function_number_of_items_parameter">(*název seznamu*)</string>
@@ -1843,7 +1843,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Výpočetní výkon</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1903,21 +1903,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Tvůj program bude nahrán na sdílecí stránku, kde si ho budou moci ostatní stáhnout. Můžes ti tam také svůj program stáhnout jako samostatnou aplikaci.</string>
     <string name="progress_upload_dialog_failed">Upload failed. Please check your internet connection and try

--- a/i18n/catroid_strings/values-da/strings.xml
+++ b/i18n/catroid_strings/values-da/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Indstillinger</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Omdøb</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">lag</item>
         <item quantity="other">lag</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrér for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hej!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Der opstod en fejl under upload af programmet.</string>
     <string name="error_project_download">Der opstod en fejl under download af programmet.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Parrede enheder</string>
     <string name="title_other_devices">Nye enheder</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Udfør</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-de/strings.xml
+++ b/i18n/catroid_strings/values-de/strings.xml
@@ -137,8 +137,8 @@
     <string name="preference_title_accessibility_large_text">Große Schrift</string>
     <string name="preference_title_accessibility_element_spacing">Erhöhter Abstand der Elemente</string>
     <string name="preference_description_accessibility_element_spacing">Diese Einstellung erhöht den Abstand zwischen interaktiven Elementen.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'Drop Verzögerung</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Fügt eine Verzögerung zu den Drag\'n\'Drop Bausteinen hinzu.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'Drop Verzögerung</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Fügt eine Verzögerung zu den Drag'n'Drop Bausteinen hinzu.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner modus</string>
     <string name="preference_description_accessibility_beginner_bricks">Zeigt Bausteine zur schnellen und einfachen Programmerstellung.</string>
     <string name="preference_title_accessibility_font_style">Schriftart auswählen</string>
@@ -156,7 +156,7 @@
     <string name="preference_access_summary_profile_odin">Großer Text, große Symbole, großer Elemente-
        Abstand, hoher Kontrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Großer Elemente-Abstand, Drag\'n\'Drop
+    <string name="preference_access_summary_profile_fenrir">Großer Elemente-Abstand, Drag'n'Drop
        Verzögerung</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Start Bausteine</string>

--- a/i18n/catroid_strings/values-el/strings.xml
+++ b/i18n/catroid_strings/values-el/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Ρυθμίσεις</string>
     <string name="preference_title_language">Γλώσσα</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Προσβασιμότητα</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Προκαθορισμένα προφίλ</string>
     <string name="preference_title_accessibility_profile_headline">Προφίλ</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Μεγάλο κείμενο</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 τούβλα</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Τούβλα Parrot Jumping Sumo</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Τούβλα Lego Mindstorms NXT</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Τούβλα Lego Mindstorms EV3</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 αισθητήρες</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
     <string name="preference_title_enable_phiro_bricks">Phiro τούβλα</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Τούβλα Arduino</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -223,11 +223,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -309,7 +309,7 @@
     <string name="am_rename">Μετονομασία</string>
     <string name="am_convert">Μετατροπή</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Σακίδιο</string>
@@ -796,7 +796,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -869,12 +869,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -901,7 +901,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1198,9 +1198,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1230,11 +1230,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1581,7 +1581,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1758,7 +1758,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Αντικείμενο</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1818,21 +1818,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1875,7 +1875,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-en-rAU/strings.xml
+++ b/i18n/catroid_strings/values-en-rAU/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-en-rCA/strings.xml
+++ b/i18n/catroid_strings/values-en-rCA/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-en-rGB/strings.xml
+++ b/i18n/catroid_strings/values-en-rGB/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">An error occurred while uploading the program.</string>
     <string name="error_project_download">An error occurred while downloading the program.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Object</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-en/strings.xml
+++ b/i18n/catroid_strings/values-en/strings.xml
@@ -139,7 +139,7 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
 
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
@@ -168,7 +168,7 @@
         text recognition bricks and sensors</string>
 
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -190,8 +190,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -210,7 +210,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -219,7 +219,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -227,8 +227,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -285,11 +285,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -384,7 +384,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
 
     <string name="list_headline_sprites">Actors and objects</string>
 
@@ -932,7 +932,7 @@
     <string name="brick_set_rotation_style">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr">left-right only</string>
     <string name="brick_set_rotation_style_normal">all-around</string>
-    <string name="brick_set_rotation_style_no">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no">don't rotate</string>
 
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
@@ -1011,12 +1011,12 @@
     <string name="brick_vibration">Vibrate for</string>
     <string name="brick_ask_label">Ask</string>
     <string name="brick_ask_store">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label">Ask</string>
     <string name="brick_ask_speech_store">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -1047,7 +1047,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait">and wait</string>
     <string name="brick_start_listening_to_voice">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1374,9 +1374,9 @@
 
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
 
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
@@ -1408,12 +1408,12 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
 
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices…</string>
@@ -1794,7 +1794,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item">item\'s index</string>
+    <string name="formula_editor_function_index_of_item">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1979,7 +1979,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -2047,14 +2047,14 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
@@ -2062,7 +2062,7 @@ needs read and write access to it. You can always change permissions through you
 
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
 
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
@@ -2112,7 +2112,7 @@ needs read and write access to it. You can always change permissions through you
     <!--  -->
 
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
 
     <!-- Symbols -->
     <string name="percent_symbol">%</string>

--- a/i18n/catroid_strings/values-fa-rIR/strings.xml
+++ b/i18n/catroid_strings/values-fa-rIR/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">تنظیمات</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">تغییر نام</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">کوله پشتی</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">لایه</item>
         <item quantity="other">لایه</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">لرزیدن برای</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">سلام!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">خطایی هنگام آپلود برنامه رخ داده است.</string>
     <string name="error_project_download">خطایی هنگام دانلود برنامه رخ داده است.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">دستگاه های متصل شده</string>
     <string name="title_other_devices">دستگاه های جدید</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(* نام لیست*، 1)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">شامل</string>
     <string name="formula_editor_function_contains_parameter">(1، *نام لیست*)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(* نام لیست*، 1)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">تعداد عناصر</string>
     <string name="formula_editor_function_number_of_items_parameter">(*نام لیست*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">محاسبه</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">شی</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-fa/strings.xml
+++ b/i18n/catroid_strings/values-fa/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -225,11 +225,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -305,7 +305,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -763,7 +763,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="other">layers</item>
     </plurals>
@@ -834,12 +834,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -866,7 +866,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1158,9 +1158,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1190,11 +1190,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1541,7 +1541,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1718,7 +1718,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1778,21 +1778,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1835,7 +1835,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-fi/strings.xml
+++ b/i18n/catroid_strings/values-fi/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-gl/strings.xml
+++ b/i18n/catroid_strings/values-gl/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Configuración</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Cambiar nome</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Mochila</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Obxecto</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">esquerda</string>
     <string name="cast_gamepad_right">dereita</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-gu/strings.xml
+++ b/i18n/catroid_strings/values-gu/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ha/strings.xml
+++ b/i18n/catroid_strings/values-ha/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-hi/strings.xml
+++ b/i18n/catroid_strings/values-hi/strings.xml
@@ -140,8 +140,8 @@
     <string name="preference_title_accessibility_large_text">बड़ा पाठ</string>
     <string name="preference_title_accessibility_element_spacing">बड़ा तत्व रिक्ति</string>
     <string name="preference_description_accessibility_element_spacing">सूचियों में तत्व रिक्ति बढ़ाएँ। </string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop देरी</string>
-    <string name="preference_description_accessibility_dragndrop_delay">ईंटों के लिए Drag\'n\'drop देरी।</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop देरी</string>
+    <string name="preference_description_accessibility_dragndrop_delay">ईंटों के लिए Drag'n'drop देरी।</string>
     <string name="preference_title_accessibility_beginner_bricks">शुरुआत ब्रिक्स</string>
     <string name="preference_description_accessibility_beginner_bricks">केवल मूल ईंटें दिखाएं।</string>
     <string name="preference_title_accessibility_font_style">एक पाठ प्रकार चुनें</string>
@@ -158,7 +158,7 @@
     <string name="preference_access_title_profile_odin">ओडिन</string>
     <string name="preference_access_summary_profile_odin">बड़े पाठ, बड़े प्रतीक, बड़े तत्व अंतर, उच्च विपरीत</string>
     <string name="preference_access_title_profile_fenrir">फेनरीर</string>
-    <string name="preference_access_summary_profile_fenrir">बड़े तत्व रिक्ति, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">बड़े तत्व रिक्ति, drag'n'drop
         विलंब</string>
     <string name="preference_access_title_profile_tiro">नवसिखुआ</string>
     <string name="preference_access_summary_profile_tiro">शुरुआत ब्रिक्स</string>

--- a/i18n/catroid_strings/values-hr/strings.xml
+++ b/i18n/catroid_strings/values-hr/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Veliki tekst</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Za početnike</string>
     <string name="preference_description_accessibility_beginner_bricks">Prikazi samo jednostavne oblike.</string>
     <string name="preference_title_accessibility_font_style">Odaberite vrstu sadržaja</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Za početnike</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Omogući aplikaciji kontrolu Lego Mindstorms NXT robota</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Senzori</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Senzori</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 konfiguracija</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino prosirenje</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -223,11 +223,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nista nije pronadjeno, molimo pokusajte kasnije.</string>
     <string name="connection_lost_or_closed_by_server">Veza sa serverom je prekinuta.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -939,7 +939,7 @@
     <string name="brick_speak_default_value">Pozdrav!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1241,9 +1241,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Doslo je do pogreske tijekom prenosenja projekta.</string>
     <string name="error_project_download">Došlo je do pogreške tijekom preuzimanja programa.</string>
@@ -1272,11 +1272,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp nije instaliran</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Upareni uređaji</string>
     <string name="title_other_devices">Novi uređaji</string>
     <string name="searching_devices">Trazenje uredjaja&#8230;</string>
@@ -1623,7 +1623,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">sadrži</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1800,7 +1800,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Izračunati</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1860,21 +1860,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">lijevo</string>
     <string name="cast_gamepad_right">desno</string>
     <string name="cast_error_not_connected_msg">Molimo povezite se na vas Chromecast prvo</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Pauzirano</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1917,7 +1917,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-hu/strings.xml
+++ b/i18n/catroid_strings/values-hu/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Beállítások</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Átnevezés</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Hátizsák</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">réteg</item>
         <item quantity="other">rétegek</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Rezgés ennyi ideig:</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Helló!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Hiba történt a program feltöltése során.</string>
     <string name="error_project_download">Hoba történt a program letöltése során.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Párosított eszközök</string>
     <string name="title_other_devices">Új eszközök</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1, *lista neve*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">tartalmazza</string>
     <string name="formula_editor_function_contains_parameter">(*lista neve*, 1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, *lista neve*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">elemek_száma</string>
     <string name="formula_editor_function_number_of_items_parameter">(*lista neve*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Kiszámítás</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objektum</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ig/strings.xml
+++ b/i18n/catroid_strings/values-ig/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -225,11 +225,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -305,7 +305,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -763,7 +763,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="other">layers</item>
     </plurals>
@@ -834,12 +834,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -866,7 +866,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1158,9 +1158,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1190,11 +1190,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1541,7 +1541,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1718,7 +1718,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1778,21 +1778,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1835,7 +1835,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-in/strings.xml
+++ b/i18n/catroid_strings/values-in/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Teks besar</string>
     <string name="preference_title_accessibility_element_spacing">Jarak elemen yang besar</string>
     <string name="preference_description_accessibility_element_spacing">Tingkatkan spasi elemen dalam daftar.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Penundaan drag\'n\'drop</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Penundaan drag\'n\'drop untuk batu bata.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Penundaan drag'n'drop</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Penundaan drag'n'drop untuk batu bata.</string>
     <string name="preference_title_accessibility_beginner_bricks">Mode pemula</string>
     <string name="preference_description_accessibility_beginner_bricks">Tampilkan hanya fitur-fitur sederhana.</string>
     <string name="preference_title_accessibility_font_style">Pilih jenis teks</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Teks besar, ikon besar, elemen besar
        jarak, kontras tinggi</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Spasi elemen besar, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Spasi elemen besar, drag'n'drop
        menunda</string>
     <string name="preference_access_title_profile_tiro">Orang yg belum berpengalaman</string>
     <string name="preference_access_summary_profile_tiro">Mode pemula</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 batu bata</string>
     <string name="preference_description_quadcopter_bricks">Izinkan aplikasi untuk mengontrol quadcopters Parrot AR.Drone 2.0</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo batu bata</string>
-    <string name="preference_description_jumpingsumo_bricks">Izinkan aplikasi untuk mengontrol robot Parrot\'s Jumping Sumo</string>
+    <string name="preference_description_jumpingsumo_bricks">Izinkan aplikasi untuk mengontrol robot Parrot's Jumping Sumo</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms Batu bata NXT</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Batu bata Lego Mindstorms EV3</string>
     <string name="preference_description_mindstorms_nxt_bricks">Izinkan aplikasi untuk mengontrol robot Lego Mindstorms NXT</string>

--- a/i18n/catroid_strings/values-it/strings.xml
+++ b/i18n/catroid_strings/values-it/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Testo grande</string>
     <string name="preference_title_accessibility_element_spacing">Aumenta spaziatura tra elementi</string>
     <string name="preference_description_accessibility_element_spacing">Aumenta spaziatura tra elementi negli elenchi.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Ritardo nel Drag \'n \'drop</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Ritardo nel Drag\'n\'drop dei mattoncini.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Ritardo nel Drag 'n 'drop</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Ritardo nel Drag'n'drop dei mattoncini.</string>
     <string name="preference_title_accessibility_beginner_bricks">Mattoncini principiante</string>
     <string name="preference_description_accessibility_beginner_bricks">Mostra solo mattoncini di base.</string>
     <string name="preference_title_accessibility_font_style">Scegli il tipo di carattere</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Testo di grandi dimensioni, icone grandi, elementi
       con ampia spaziatura e alto contrasto</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Elementi molto distanziati, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Elementi molto distanziati, drag'n'drop
        con ritardo</string>
     <string name="preference_access_title_profile_tiro">Shoot</string>
     <string name="preference_access_summary_profile_tiro">Mattoncini principiante</string>

--- a/i18n/catroid_strings/values-iw/strings.xml
+++ b/i18n/catroid_strings/values-iw/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">הגדרות</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -231,11 +231,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -329,7 +329,7 @@
     <string name="am_rename">שנה שם</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -877,7 +877,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">שכבה</item>
         <item quantity="two">layers</item>
@@ -954,12 +954,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -986,7 +986,7 @@
     <string name="brick_speak_default_value">שלום!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1293,9 +1293,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1325,11 +1325,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">התאם התקן</string>
     <string name="title_other_devices">התקן חדש</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1676,7 +1676,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">מכיל</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">מספר האברים</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1853,7 +1853,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">אובייקט</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1913,21 +1913,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1970,7 +1970,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ka/strings.xml
+++ b/i18n/catroid_strings/values-ka/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-kab/strings.xml
+++ b/i18n/catroid_strings/values-kab/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-kk/strings.xml
+++ b/i18n/catroid_strings/values-kk/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Үлкен мәтін</string>
     <string name="preference_title_accessibility_element_spacing">Үлкен элементтер аралығы</string>
     <string name="preference_description_accessibility_element_spacing">Тізімдердегі элементтер аралығын көбейту.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop кідірту</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Блоктар үшін drag\'n\'drop кідірту.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop кідірту</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Блоктар үшін drag'n'drop кідірту.</string>
     <string name="preference_title_accessibility_beginner_bricks">Қарапайым режим</string>
     <string name="preference_description_accessibility_beginner_bricks">Тек қарапайым мүмкіндіктерді көрсету.</string>
     <string name="preference_title_accessibility_font_style">Мәтін түрін таңдаңыз</string>
@@ -156,14 +156,14 @@
     <string name="preference_access_title_profile_odin">Один</string>
     <string name="preference_access_summary_profile_odin">Үлкен мәтін, үлкен белгішелер, үлкен элементтер        аралығы, жоғары контраст</string>
     <string name="preference_access_title_profile_fenrir">Фенрир</string>
-    <string name="preference_access_summary_profile_fenrir">Үлкен элементтер аралығы, drag\'n\'drop        кідірту</string>
+    <string name="preference_access_summary_profile_fenrir">Үлкен элементтер аралығы, drag'n'drop        кідірту</string>
     <string name="preference_access_title_profile_tiro">Тиро</string>
     <string name="preference_access_summary_profile_tiro">Қарапайым режим</string>
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 кеңейтімі</string>
     <string name="preference_description_quadcopter_bricks">Қолданбаға Parrot AR.Drone 2.0 квадкоптарын басқаруға рұқсат ету</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo кеңейтімі</string>
-    <string name="preference_description_jumpingsumo_bricks">Қолданбаға Parrot\'s Jumping Sumo роботтарын басқаруға рұқсат ету</string>
+    <string name="preference_description_jumpingsumo_bricks">Қолданбаға Parrot's Jumping Sumo роботтарын басқаруға рұқсат ету</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT кеңейтімі</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 кеңейтімі</string>
     <string name="preference_description_mindstorms_nxt_bricks">Қолданбаға Lego Mindstorms NXT роботтарын басқаруға рұқсат ету</string>
@@ -782,7 +782,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -855,12 +855,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -887,7 +887,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1184,9 +1184,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1216,11 +1216,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1567,7 +1567,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1744,7 +1744,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1804,21 +1804,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1861,7 +1861,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-kn/strings.xml
+++ b/i18n/catroid_strings/values-kn/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">ಸೆಟ್ಟಿಂಗ್ಗಳು</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">ಮರುಹೆಸರಿಸಿ</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">ಬ್ಯಾಕ್ ಪ್ಯಾಕ್</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-lt/strings.xml
+++ b/i18n/catroid_strings/values-lt/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -231,11 +231,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -329,7 +329,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -877,7 +877,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="few">layers</item>
@@ -954,12 +954,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -986,7 +986,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1293,9 +1293,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1325,11 +1325,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1676,7 +1676,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1853,7 +1853,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1913,21 +1913,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1970,7 +1970,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-mk/strings.xml
+++ b/i18n/catroid_strings/values-mk/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Преименувај</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ml-rIN/strings.xml
+++ b/i18n/catroid_strings/values-ml-rIN/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">പോക്കറ്റ് കോഡ്</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ml/strings.xml
+++ b/i18n/catroid_strings/values-ml/strings.xml
@@ -109,12 +109,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -134,8 +134,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -153,7 +153,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -161,7 +161,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -169,8 +169,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -223,11 +223,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -309,7 +309,7 @@
     <string name="am_rename">പോക്കറ്റ് കോഡ്</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -597,13 +597,13 @@
     <!--  -->
     <!-- Terms of Use Dialog Parrot ARDrone-->
     <string name="dialog_terms_of_use_link_text_parrot_reminder">Terms of Use and Service</string>
-    <string name="dialog_terms_of_use_parrot_reminder_text">You are about to use this app together with Parrot\'s
-        AR.Drone 2.0. We strongly remind you to abide by both Parrot\'s and Catrobat\'s Terms of Use and Services.</string>
+    <string name="dialog_terms_of_use_parrot_reminder_text">You are about to use this app together with Parrot's
+        AR.Drone 2.0. We strongly remind you to abide by both Parrot's and Catrobat's Terms of Use and Services.</string>
     <string name="dialog_terms_of_use_parrot_reminder_do_not_remind_again">Do not remind me again.</string>
     <!--  -->
     <!-- Terms of Use Dialog Parrot Jumping Sumo-->
     <string name="dialog_terms_of_use_jumpingsumo_reminder_text">You are about to use this app together with
-        Parrot\'s Jumping Sumo. We strongly remind you to abide by both Parrot\'s and Catrobat\'s Terms of Use and
+        Parrot's Jumping Sumo. We strongly remind you to abide by both Parrot's and Catrobat's Terms of Use and
         Services.</string>
     <!--  -->
     <!-- Privacy Policy -->
@@ -811,7 +811,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -884,12 +884,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -916,7 +916,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1217,15 +1217,15 @@
         behavior.</string>
     <string name="drone_emergency_cutout">One or more motors were stopped by environment.</string>
     <string name="drone_alert_battery_low">Battery is too low to take off again.</string>
-    <string name="drone_alert_ultrasound">Ultrasound sensor can\'t determine AR.Drone 2.0 altitude.</string>
+    <string name="drone_alert_ultrasound">Ultrasound sensor can't determine AR.Drone 2.0 altitude.</string>
     <string name="drone_alert_vision">No speed estimation from bottom facing camera.</string>
     <string name="drone_emergency_title">Emergency</string>
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1267,11 +1267,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1618,7 +1618,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1794,7 +1794,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1854,21 +1854,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1894,7 +1894,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ms/strings.xml
+++ b/i18n/catroid_strings/values-ms/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -225,11 +225,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -305,7 +305,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -763,7 +763,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="other">layers</item>
     </plurals>
@@ -834,12 +834,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -866,7 +866,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1158,9 +1158,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1190,11 +1190,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1541,7 +1541,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1718,7 +1718,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1778,21 +1778,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1835,7 +1835,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-nl/strings.xml
+++ b/i18n/catroid_strings/values-nl/strings.xml
@@ -87,7 +87,7 @@
     <!-- Main Menu -->
     <string name="main_menu_continue">Continue project</string>
     <string name="main_menu_new">New project</string>
-    <string name="main_menu_programs">Programma\'s</string>
+    <string name="main_menu_programs">Programma's</string>
     <string name="main_menu_help" tools:ignore="UnusedResources">Help</string>
     <string name="main_menu_web">Catrobat community</string>
     <string name="main_menu_upload">Upload programma</string>
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Instellingen</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Hernoemen</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -489,7 +489,7 @@
     </plurals>
     <!--  -->
     <!-- ProjectListActivity and ProjectListFragment -->
-    <string name="project_list_title">Programma\'s</string>
+    <string name="project_list_title">Programma's</string>
     <string name="last_used">Laatste aanmelding:</string>
     <string name="size">Grootte:</string>
     <string name="description">Omschrijving:</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">laag</item>
         <item quantity="other">lagen terug</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Tril</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hallo!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Er is een fout opgetreden tijdens het uploaden van het programma.</string>
     <string name="error_project_download">Er is een fout opgetreden tijdens het downloaden van het programma.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Gekoppelde apparaten</string>
     <string name="title_other_devices">Nieuwe apparaten</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Berekenen</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Object</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-no/strings.xml
+++ b/i18n/catroid_strings/values-no/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Innstillinger</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">LEGO Mindstorms NXT blokker</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">LEGO Mindstorms EV3 blokker</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">LEGO EV3 sensorer</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
     <string name="preference_title_enable_phiro_bricks">Phiro blokker</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino blokker</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -223,11 +223,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -309,7 +309,7 @@
     <string name="am_rename">Gi nytt navn</string>
     <string name="am_convert">Konverter</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -869,12 +869,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrer i</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Spør</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">og lagre skriftlig svar i</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Skriv inn svaret:"</string>
     <string name="brick_ask_dialog_submit">Send svar</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Spør</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">og lagre talte svar i</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -901,7 +901,7 @@
     <string name="brick_speak_default_value">Hei!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">og vent</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1198,9 +1198,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Det oppstod en feil under opplasting av programmet.</string>
     <string name="error_project_download">Det oppstod en feil under nedlasting av programmet.</string>
@@ -1230,11 +1230,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Sammenkoblede enheter</string>
     <string name="title_other_devices">Nye enheter</string>
     <string name="searching_devices">Leter etter enheter&#8230;</string>
@@ -1575,7 +1575,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1, * liste navn *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">inneholder</string>
     <string name="formula_editor_function_contains_parameter">(* liste navn *, 1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, * liste navn *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">antall_elementer</string>
     <string name="formula_editor_function_number_of_items_parameter">(* liste navn *)</string>
@@ -1752,7 +1752,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Beregn</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1812,21 +1812,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Ditt program blir lastet opp til nettsamfunnet der andre kan bruke og laste det ned.         Man kan også laste ned programmet som frittstående app.</string>
     <string name="progress_upload_dialog_failed">Upload failed. Please check your internet connection and try
@@ -1868,7 +1868,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-pl/strings.xml
+++ b/i18n/catroid_strings/values-pl/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Duży tekst</string>
     <string name="preference_title_accessibility_element_spacing">Duże odstępy między elementami</string>
     <string name="preference_description_accessibility_element_spacing">Zwiększ odstępy między elementami w listach.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Opóźnienie drag\'n\'drop (przeciągnij i upuść)</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Opóźnienie drag\'n\'drop dla bloków.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Opóźnienie drag'n'drop (przeciągnij i upuść)</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Opóźnienie drag'n'drop dla bloków.</string>
     <string name="preference_title_accessibility_beginner_bricks">Bloczki dla początkujących</string>
     <string name="preference_description_accessibility_beginner_bricks">Pokaż tylko podstawowe bloki.</string>
     <string name="preference_title_accessibility_font_style">Wybierz czcionkę</string>

--- a/i18n/catroid_strings/values-ps/strings.xml
+++ b/i18n/catroid_strings/values-ps/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-pt-rBR/strings.xml
+++ b/i18n/catroid_strings/values-pt-rBR/strings.xml
@@ -164,7 +164,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Extensão Parrot AR.Drone 2.0</string>
     <string name="preference_description_quadcopter_bricks">Permite ao aplicativo controlar os quadricópteros Parrot AR.Drone 2.0</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Extensão Parrot Jumping Sumo</string>
-    <string name="preference_description_jumpingsumo_bricks">Permitir que o aplicativo controle os robôs Parrot\'s Jumping Sumo</string>
+    <string name="preference_description_jumpingsumo_bricks">Permitir que o aplicativo controle os robôs Parrot's Jumping Sumo</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Extensão Lego Mindstorms NXT</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Extensão Lego Mindstorms EV3</string>
     <string name="preference_description_mindstorms_nxt_bricks">Permitir o aplicativo controlar os robôs Lego Mindstorms NXT</string>
@@ -172,8 +172,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Sensores Lego NXT</string>
     <string name="preference_title_mindstorms_ev3_sensors">Sensores Lego EV3</string>
     <string name="preference_title_drone_config_properties">Configuração do Parrot AR.Drone 2.0</string>
-    <string name="preference_title_enable_phiro_bricks">Extensão RobotixEdu\'s Phiro</string>
-    <string name="preference_description_phiro_bricks">Permitir que o aplicativo controle robôs RobotixEdu\'s Phiro</string>
+    <string name="preference_title_enable_phiro_bricks">Extensão RobotixEdu's Phiro</string>
+    <string name="preference_description_phiro_bricks">Permitir que o aplicativo controle robôs RobotixEdu's Phiro</string>
     <string name="preference_title_enable_arduino_bricks">Extensão Arduino</string>
     <string name="preference_description_arduino_bricks">Permitir que o aplicativo controle as placas da Arduino</string>
     <string name="preference_title_enable_embroidery_bricks">Extensão Embroidery</string>

--- a/i18n/catroid_strings/values-pt/strings.xml
+++ b/i18n/catroid_strings/values-pt/strings.xml
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Modo de principiante</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Blocos de Lego Mindstorms NXT</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
     <string name="preference_title_enable_phiro_bricks">Blocos Phiro</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Blocos Arduino</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -224,11 +224,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -310,7 +310,7 @@
     <string name="am_rename">Renomear</string>
     <string name="am_convert">Converter</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Mochila</string>
@@ -870,12 +870,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrar para</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -902,7 +902,7 @@
     <string name="brick_speak_default_value">Olá!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1199,9 +1199,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Ocorreu um erro ao fazer o upload do programa.</string>
     <string name="error_project_download">Ocorreu um erro ao descarregar o programa.</string>
@@ -1231,11 +1231,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Dispositivos pareados</string>
     <string name="title_other_devices">Novos dispositivos</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1582,7 +1582,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*nome da lista*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contém</string>
     <string name="formula_editor_function_contains_parameter">(*nome da lista*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*nome da lista*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">numero_de_itens</string>
     <string name="formula_editor_function_number_of_items_parameter">(*nome da lista*)</string>
@@ -1759,7 +1759,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Calcular</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objeto</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1819,21 +1819,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1876,7 +1876,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ro/strings.xml
+++ b/i18n/catroid_strings/values-ro/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Setări</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -229,11 +229,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -321,7 +321,7 @@
     <string name="am_rename">Redenumire</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -839,7 +839,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">strat</item>
         <item quantity="few">straturi</item>
@@ -914,12 +914,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibreze pentru</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -946,7 +946,7 @@
     <string name="brick_speak_default_value">Salut!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1248,9 +1248,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">O eroare a avut loc la încărcarea proiectului.</string>
     <string name="error_project_download">O eroare a avut loc la descărcarea proiectului.</string>
@@ -1280,11 +1280,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Dispozitive îmeprecheate</string>
     <string name="title_other_devices">Dispozitive noi</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1631,7 +1631,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1808,7 +1808,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Calculă</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">obiect</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1868,21 +1868,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1925,7 +1925,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ru/strings.xml
+++ b/i18n/catroid_strings/values-ru/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Крупный текст</string>
     <string name="preference_title_accessibility_element_spacing">Большой отступ между элементами</string>
     <string name="preference_description_accessibility_element_spacing">Увеличьте интервал между элементами в списках.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop задержка</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop задержка для блоков.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop задержка</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop задержка для блоков.</string>
     <string name="preference_title_accessibility_beginner_bricks">Простой режим</string>
     <string name="preference_description_accessibility_beginner_bricks">Показать только простые функции.</string>
     <string name="preference_title_accessibility_font_style">Выберите тип текста</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Большой текст, крупные значки, Большой отступ между
        элементами, высокая контрастность</string>
     <string name="preference_access_title_profile_fenrir">Фенрир</string>
-    <string name="preference_access_summary_profile_fenrir">Большой отступ между элементами, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Большой отступ между элементами, drag'n'drop
        задержка</string>
     <string name="preference_access_title_profile_tiro">Тиро</string>
     <string name="preference_access_summary_profile_tiro">Простой режим</string>

--- a/i18n/catroid_strings/values-sd/strings.xml
+++ b/i18n/catroid_strings/values-sd/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">سيٽنگ</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">ليگو مائنڊاسٽورمز اين ايڪس ٽي برڪس</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">ليگو مائنڊاسٽورمز اِي وِي3 برڪس</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">ليگو اين ايڪس ٽي سينسرز</string>
     <string name="preference_title_mindstorms_ev3_sensors">ليگو اي وي3 سينسرز</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">نالو ماٽيو</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">بيڪ پيڪ</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">پڇو</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"پنهنجو نالي لکو"</string>
     <string name="brick_ask_dialog_submit">جواب جمع ڪريو</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">پڇو</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">آبجيڪٽ</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-si/strings.xml
+++ b/i18n/catroid_strings/values-si/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-sk/strings.xml
+++ b/i18n/catroid_strings/values-sk/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Nastavenia</string>
     <string name="preference_title_language">Jazyk</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 bloky</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo bloky</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT bloky</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 bloky</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 senzory</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
     <string name="preference_title_enable_phiro_bricks">Phiro bloky</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino bloky</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -325,7 +325,7 @@
     <string name="am_rename">Premenovať</string>
     <string name="am_convert">Konvertovať</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Objekty</string>
     <!-- Options Menu Options -->
     <string name="backpack">Batoh</string>
@@ -949,12 +949,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrovať</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Opýtať sa</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">a uložiť napísanú odpoveď v</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Zadaj odpoveď:"</string>
     <string name="brick_ask_dialog_submit">Odoslať odpoveď</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Opýtať sa</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">a uložiť povedanú odpoveď v</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -981,7 +981,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">a čakaj</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1288,9 +1288,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1320,11 +1320,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1669,7 +1669,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1846,7 +1846,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1906,21 +1906,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1963,7 +1963,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-sl/strings.xml
+++ b/i18n/catroid_strings/values-sl/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Nastavitve</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -231,11 +231,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -329,7 +329,7 @@
     <string name="am_rename">Preimenuj</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Nahrbtnik</string>
@@ -877,7 +877,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">plast</item>
         <item quantity="two">plasta</item>
@@ -954,12 +954,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrirati za</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -986,7 +986,7 @@
     <string name="brick_speak_default_value">zdravo!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1293,9 +1293,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Med nalaganjem programa je prišlo do napake.</string>
     <string name="error_project_download">Med prenosom programa je prišlo do napake.</string>
@@ -1325,11 +1325,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Povezane naprave</string>
     <string name="title_other_devices">Nova naprava</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1676,7 +1676,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*ime seznama*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">vsebuje</string>
     <string name="formula_editor_function_contains_parameter">(*ime seznama*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*ime seznama*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number_of_items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*ime seznama*)</string>
@@ -1853,7 +1853,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Izračuni</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1913,21 +1913,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1970,7 +1970,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-sq/strings.xml
+++ b/i18n/catroid_strings/values-sq/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Parametrat</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Riemërto</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Përshëndetje!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-sr-rCS/strings.xml
+++ b/i18n/catroid_strings/values-sr-rCS/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Veliki tekst</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Početni režim</string>
     <string name="preference_description_accessibility_beginner_bricks">Prikaži samo jednostavne funkcije.</string>
     <string name="preference_title_accessibility_font_style">Odaberite tip teksta</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Veliki tekst, velike ikone, veliki razmak
   elemenata, visoki kontrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Početni režim</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 ekstenzija</string>
     <string name="preference_description_quadcopter_bricks">Dopustiti aplikaciji kontrolu ARDrone 2.0 quadcoptera</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo ekstenzija</string>
-    <string name="preference_description_jumpingsumo_bricks">Dopustiti aplikaciji kontrolu Parrot\'s Jumping Sumo robota</string>
+    <string name="preference_description_jumpingsumo_bricks">Dopustiti aplikaciji kontrolu Parrot's Jumping Sumo robota</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT ekstenzija</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 ekstenzija</string>
     <string name="preference_description_mindstorms_nxt_bricks">Dopustiti aplikaciji kontrolu Lego Mindstorms NXT robota</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT senzori</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 senzori</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 konfiguracija</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro ekstenzija</string>
-    <string name="preference_description_phiro_bricks">Dopustiti aplikaciji kontrolu RobotixEdu\'s Phiro robota</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro ekstenzija</string>
+    <string name="preference_description_phiro_bricks">Dopustiti aplikaciji kontrolu RobotixEdu's Phiro robota</string>
     <string name="preference_title_enable_arduino_bricks">Arduino ekstenzija</string>
     <string name="preference_description_arduino_bricks">Doputiti aplikaciji da kontroliše Arduino ploče</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery ekstenzija</string>
@@ -229,7 +229,7 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Ništa nije pronađeno, molimo Vas pokušajte ponovo.</string>
     <string name="connection_lost_or_closed_by_server">Veza sa serverom izgubljena.</string>
@@ -946,7 +946,7 @@
     <string name="brick_speak_default_value">Zdravo!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">i čekaj</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1248,9 +1248,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Došlo je do greške prilikom otpremanja projekta.</string>
     <string name="error_project_download">Došlo je do greške prilikom preuzimanja projekta.</string>
@@ -1280,7 +1280,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp nije instaliran</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
@@ -1631,7 +1631,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*ime liste*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">sadrži</string>
     <string name="formula_editor_function_contains_parameter">(*ime liste*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*ime liste*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">broj stavki</string>
     <string name="formula_editor_function_number_of_items_parameter">(*ime liste*)</string>
@@ -1808,7 +1808,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">Ovde možete da napravite
         svoju formulu,  kao na vašem digitronu.</string>
     <string name="formula_editor_intro_title_compute">Računaj</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Svojstva</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1868,7 +1868,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">levo</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Prvo se povežite sa vašim Chromecast</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
@@ -1882,7 +1882,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>

--- a/i18n/catroid_strings/values-sr-rSP/strings.xml
+++ b/i18n/catroid_strings/values-sr-rSP/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Велики текст</string>
     <string name="preference_title_accessibility_element_spacing">Велико одстојање елемента</string>
     <string name="preference_description_accessibility_element_spacing">Повећај одстојање елемента у листама.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay за bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay за bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Почетнички мод</string>
     <string name="preference_description_accessibility_beginner_bricks">Прикажи само једноставне одлике.</string>
     <string name="preference_title_accessibility_font_style">Изабери тип текста</string>
@@ -156,14 +156,14 @@
     <string name="preference_access_title_profile_odin">Odin</string>
     <string name="preference_access_summary_profile_odin">Велик текст, велике иконице, велик размак елемента, високи контраст</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Велики размак елемента, drag\'n\'drop одлагање</string>
+    <string name="preference_access_summary_profile_fenrir">Велики размак елемента, drag'n'drop одлагање</string>
     <string name="preference_access_title_profile_tiro">Тиро</string>
     <string name="preference_access_summary_profile_tiro">Почетнички мод</string>
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 екстензија</string>
     <string name="preference_description_quadcopter_bricks">Дозволи да апликација контролише Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo екстензија</string>
-    <string name="preference_description_jumpingsumo_bricks">Дозволи да апликација контролише Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Дозволи да апликација контролише Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT екстензија</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 екстензија</string>
     <string name="preference_description_mindstorms_nxt_bricks">Дозволи да апликација контролише Lego Mindstorms NXT robots</string>
@@ -171,8 +171,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Сензори</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Сензори</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 конфигурација</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro екстензија</string>
-    <string name="preference_description_phiro_bricks">Дозволи да апликација контролише RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro екстензија</string>
+    <string name="preference_description_phiro_bricks">Дозволи да апликација контролише RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino екстензија</string>
     <string name="preference_description_arduino_bricks">Дозволи да апликација контролише Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery екстензија</string>
@@ -219,7 +219,7 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Ништа није пронађено. Покушајте поново касније.</string>
     <string name="connection_lost_or_closed_by_server">Веза са сервером је изгубљена.</string>
@@ -904,7 +904,7 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
@@ -936,7 +936,7 @@
     <string name="brick_speak_default_value">Здраво!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">и чекај</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1270,11 +1270,11 @@
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1615,7 +1615,7 @@
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1792,7 +1792,7 @@
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1852,14 +1852,14 @@
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
@@ -1908,7 +1908,7 @@
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-sr/strings.xml
+++ b/i18n/catroid_strings/values-sr/strings.xml
@@ -127,8 +127,8 @@
     <string name="preference_title_accessibility_large_text">Велики текст</string>
     <string name="preference_title_accessibility_element_spacing">Велико одстојање елемента</string>
     <string name="preference_description_accessibility_element_spacing">Повећај одстојање елемента у листама.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay за bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay за bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Почетнички мод</string>
     <string name="preference_description_accessibility_beginner_bricks">Прикажи само једноставне одлике.</string>
     <string name="preference_title_accessibility_font_style">Изабери тип текста</string>
@@ -145,14 +145,14 @@
     <string name="preference_access_title_profile_odin">Odin</string>
     <string name="preference_access_summary_profile_odin">Велик текст, велике иконице, велик размак елемента, високи контраст</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Велики размак елемента, drag\'n\'drop одлагање</string>
+    <string name="preference_access_summary_profile_fenrir">Велики размак елемента, drag'n'drop одлагање</string>
     <string name="preference_access_title_profile_tiro">Тиро</string>
     <string name="preference_access_summary_profile_tiro">Почетнички мод</string>
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 екстензија</string>
     <string name="preference_description_quadcopter_bricks">Дозволи да апликација контролише Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo екстензија</string>
-    <string name="preference_description_jumpingsumo_bricks">Дозволи да апликација контролише Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Дозволи да апликација контролише Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT екстензија</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 екстензија</string>
     <string name="preference_description_mindstorms_nxt_bricks">Дозволи да апликација контролише Lego Mindstorms NXT robots</string>
@@ -160,8 +160,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Сензори</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Сензори</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 конфигурација</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro екстензија</string>
-    <string name="preference_description_phiro_bricks">Дозволи да апликација контролише RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro екстензија</string>
+    <string name="preference_description_phiro_bricks">Дозволи да апликација контролише RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino екстензија</string>
     <string name="preference_description_arduino_bricks">Дозволи да апликација контролише Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery екстензија</string>
@@ -208,7 +208,7 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Ништа није пронађено. Покушајте поново касније.</string>
     <string name="connection_lost_or_closed_by_server">Веза са сервером је изгубљена.</string>
@@ -606,13 +606,13 @@
     <!--  -->
     <!-- Terms of Use Dialog Parrot ARDrone-->
     <string name="dialog_terms_of_use_link_text_parrot_reminder">Услови коришћења и услуге</string>
-    <string name="dialog_terms_of_use_parrot_reminder_text">You are about to use this app together with Parrot\'s
-        AR.Drone 2.0. We strongly remind you to abide by both Parrot\'s and Catrobat\'s Terms of Use and Services.</string>
+    <string name="dialog_terms_of_use_parrot_reminder_text">You are about to use this app together with Parrot's
+        AR.Drone 2.0. We strongly remind you to abide by both Parrot's and Catrobat's Terms of Use and Services.</string>
     <string name="dialog_terms_of_use_parrot_reminder_do_not_remind_again">Do not remind me again.</string>
     <!--  -->
     <!-- Terms of Use Dialog Parrot Jumping Sumo-->
     <string name="dialog_terms_of_use_jumpingsumo_reminder_text">You are about to use this app together with
-        Parrot\'s Jumping Sumo. We strongly remind you to abide by both Parrot\'s and Catrobat\'s Terms of Use and
+        Parrot's Jumping Sumo. We strongly remind you to abide by both Parrot's and Catrobat's Terms of Use and
         Services.</string>
     <!--  -->
     <!-- Privacy Policy -->
@@ -631,7 +631,7 @@
             information (last bits of the IP address get anonymized). However, the collected data will get
             transferred to the service-provider (Google LLC, USA and Dynatrace LLC, USA). 
             Data processing is based on agreements with Google LLC and Dynatrace LLC. 
-            This relationship to the service provider conforms to the European Union\'s General Data
+            This relationship to the service provider conforms to the European Union's General Data
             Protection Regulation (EU GDPR) and EU-USA \"Privacy Shield\" agreement.\n\n
         • To create and use an account in our systems, and to inform you about necessary changes about your
             account per e-mail, e.g., updates or violations of our Terms of Use and Service, our community rules, or
@@ -659,7 +659,7 @@
             the newsletter at any time by using the \"unsubscribe\" link in the footer of every newsletter. This
             newsletter is provided by MailChimp with whom we do have a data-processing agreement and who committed to
             the EU General Data Protection Regulation and EU-USA \"Privacy Shield\". For further details on MailChimp
-            please also look up MailChimp\'s Privacy Policy and Terms of Use.\n\n
+            please also look up MailChimp's Privacy Policy and Terms of Use.\n\n
         • All Services are provided by the free open source Catrobat project under the umbrella of the
             International Catrobat Association – Verein zur Förderung freier Software, a non-profit NGO incorporated
             in Graz, Austria (European Union). Our policies pay respect to EU and Austrian data protection law
@@ -672,7 +672,7 @@
                 (European Union).\n\n
         In case you are below the age of 14, this policy must be accepted by a legal guardian (usually a parent).\n\n
 
-        Catrobat\'s official English language privacy policy is available on the web under
+        Catrobat's official English language privacy policy is available on the web under
         https://catrob.at/privacypolicy.\n\n
 
         Version 2.2, 17 October 2019\n\n
@@ -953,7 +953,7 @@
     <string name="brick_vibration">Vibrate for</string>
     <string name="brick_ask_label">Ask</string>
     <string name="brick_ask_store">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label">Ask</string>
@@ -985,7 +985,7 @@
     <string name="brick_speak_default_value">Здраво!</string>
     <string name="brick_speak_and_wait">и чекај</string>
     <string name="brick_start_listening_to_voice">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1339,11 +1339,11 @@
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1684,7 +1684,7 @@
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item">item\'s index</string>
+    <string name="formula_editor_function_index_of_item">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1849,7 +1849,7 @@
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1907,21 +1907,21 @@
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <string name="deletion_alert_yes">Yes, delete anyway!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
@@ -1948,7 +1948,7 @@
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol">㎐</string>

--- a/i18n/catroid_strings/values-sv/strings.xml
+++ b/i18n/catroid_strings/values-sv/strings.xml
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Stor text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Nybörjarläge</string>
     <string name="preference_description_accessibility_beginner_bricks">Visa endast enkla funktioner.</string>
     <string name="preference_title_accessibility_font_style">Välj en texttyp</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Nybörjarläge</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0-konfiguration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro-tillägg</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro-tillägg</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Broderi-tillägg</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Ingenting hittades, försök igen senare.</string>
     <string name="connection_lost_or_closed_by_server">Serveranslutning förlorad.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hallå!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">och vänta</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Ett fel uppstod när du ladda upp programmet.</string>
     <string name="error_project_download">Ett fel uppstod när du ladda ner programmet.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp inte installerad</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Ihopkopplade enheter</string>
     <string name="title_other_devices">Nya enheter</string>
     <string name="searching_devices">Letar efter enheter&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">innehåller</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number_of_items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Beräkna</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Objekt</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">vänster</string>
     <string name="cast_gamepad_right">höger</string>
     <string name="cast_error_not_connected_msg">Vänligen anslut till din Chromecast först</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Söker efter Chromecast-enheter</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Ta bort?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>

--- a/i18n/catroid_strings/values-sw/strings.xml
+++ b/i18n/catroid_strings/values-sw/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Mipangilio</string>
     <string name="preference_title_language">Lugha</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Mkondo wa vifaa unganiko NXT matofari</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Mkondo wa vifaa unganiko EV3 matofari</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -174,7 +174,7 @@
     <string name="preference_title_mindstorms_ev3_sensors">Lego NXT Vihisio</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
     <string name="preference_title_enable_phiro_bricks">Matofari ya phiro</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Matofali ya Arduino</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -223,11 +223,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -309,7 +309,7 @@
     <string name="am_rename">Andika jina upya</string>
     <string name="am_convert">Geuza</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Mkoba</string>
@@ -869,12 +869,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Tetemesha kwa</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Uliza</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">na hifadhi majibu yaliyoandikwa kwenye</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Ingiza jibu lako:"</string>
     <string name="brick_ask_dialog_submit">Tuma majibu</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Uliza</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">na hifadhi majibu yaliyosemwa kwenye</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -901,7 +901,7 @@
     <string name="brick_speak_default_value">Habari!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">na subiri</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1198,9 +1198,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Kosa limetokea wakati wa kupakia programu.</string>
     <string name="error_project_download">Kosa limetokea wakati wa kupakua programu.</string>
@@ -1230,11 +1230,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp haija wekwa</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Vifaa vya jozi</string>
     <string name="title_other_devices">Vifaa vipya</string>
     <string name="searching_devices">Inatafuta vifaa&#8230;</string>
@@ -1575,7 +1575,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*orodhesha jina*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">ina</string>
     <string name="formula_editor_function_contains_parameter">(*orodhesha jina*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*orodhesha jina*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">namba_ya_vipengele</string>
     <string name="formula_editor_function_number_of_items_parameter">(*jina la orodha*)</string>
@@ -1806,14 +1806,14 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_ready_to_cast">Tayari kutupwa kwenye</string>
     <string name="cast_enable_cast_feature">Vipengele vya kutupwa havijawezeshwa. Tafadhali wezesha vipengele vya kutupwa kwenye vipimo.</string>
     <string name="cast_searching_for_cast_devices">Inatafuta vifaa vya kutupwa</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Uunganisho umeisha muda wake. Tafadhali jaribu tena.</string>
     <string name="cast_screen_pause_text">Umesitishwa</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Programu yako inapakiwa kwenye tovuti ya kushirikisha programu ambapo wengine wanaweza kutumia na kuipakua. Unaweza pia kupakua programu yako kama programu yenyewe.</string>
     <string name="progress_upload_dialog_failed">Upload failed. Please check your internet connection and try
@@ -1855,7 +1855,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ta/strings.xml
+++ b/i18n/catroid_strings/values-ta/strings.xml
@@ -156,14 +156,14 @@
     <string name="preference_access_title_profile_odin">ஒடின்</string>
     <string name="preference_access_summary_profile_odin">பெரிய உரை, பெரிய சின்னங்கள், பெரிய உறுப்பு, இடைவெளி, உயர் மாறுபாடு</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">பெரிய உறுப்பு இடைவெளி, drag\'n\'drop, தாமதம்</string>
+    <string name="preference_access_summary_profile_fenrir">பெரிய உறுப்பு இடைவெளி, drag'n'drop, தாமதம்</string>
     <string name="preference_access_title_profile_tiro">டிரோ</string>
     <string name="preference_access_summary_profile_tiro">தொடக்க முறை</string>
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 நீட்டிப்பு</string>
     <string name="preference_description_quadcopter_bricks">Parrot AR.Drone 2.0 குவாட்காப்டர்களைக் கட்டுப்படுத்த பயன்பாட்டை அனுமதிக்கவும்</string>
     <string name="preference_title_enable_jumpingsumo_bricks">கிளி ஜம்பிங் சுமோ நீட்டிப்பு</string>
-    <string name="preference_description_jumpingsumo_bricks">Parrot\'s ஜம்பிங் சுமோ ரோபோக்களைக் கட்டுப்படுத்த பயன்பாட்டை அனுமதிக்கவும்</string>
+    <string name="preference_description_jumpingsumo_bricks">Parrot's ஜம்பிங் சுமோ ரோபோக்களைக் கட்டுப்படுத்த பயன்பாட்டை அனுமதிக்கவும்</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">லெகோ மைண்ட்ஸ்டார்ம்ஸ் என்எக்ஸ்டி நீட்டிப்பு</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">லெகோ மைண்ட்ஸ்டார்ம்ஸ் EV3 நீட்டிப்பு</string>
     <string name="preference_description_mindstorms_nxt_bricks">லெகோ மைண்ட்ஸ்டார்ம்ஸ் என்எக்ஸ்டி ரோபோக்களைக் கட்டுப்படுத்த பயன்பாட்டை அனுமதிக்கவும்</string>
@@ -897,7 +897,7 @@
     <string name="brick_speak_default_value">வணக்கம்!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">காத்திருங்கள்</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1564,7 +1564,7 @@
     <string name="formula_editor_function_list_item_parameter">(1, * பட்டியல் பெயர் *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">உள் அடக்கி வை</string>
     <string name="formula_editor_function_contains_parameter">( * பட்டியல் பெயர் *,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, * பட்டியல் பெயர் *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">பொருட்களின் எண்ணிக்கை</string>
     <string name="formula_editor_function_number_of_items_parameter">( * பட்டியல் பெயர் *)</string>
@@ -1804,7 +1804,7 @@
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">உங்கள் திட்டம் பயன்பாட்டின் பகிர்வு தளத்தில் பதிவேற்றப்படும்
 மற்றவர்கள் அதைப் பயன்படுத்தலாம் மற்றும் பதிவிறக்கலாம். உங்கள் திட்டத்தை முழுமையான செயலியாகவும் பதிவிறக்கலாம்.</string>

--- a/i18n/catroid_strings/values-te/strings.xml
+++ b/i18n/catroid_strings/values-te/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">అమరికలు</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">పేరు మార్చు</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">బ్యాగు</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-th/strings.xml
+++ b/i18n/catroid_strings/values-th/strings.xml
@@ -163,7 +163,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">อนุญาตให้แอปควบคุม Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -171,8 +171,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -1513,7 +1513,7 @@
     <string name="formula_editor_function_list_item_parameter">(1, *ชื่อรายการ*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">ประกอบด้วย</string>
     <string name="formula_editor_function_contains_parameter">(*ชื่อรายการ*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, *ชื่อรายการ*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">จำนวนรายการ</string>
     <string name="formula_editor_function_number_of_items_parameter">(*ชื่อรายการ*)</string>
@@ -1687,7 +1687,7 @@
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">คำนวณ</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">วัตถุ</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1747,14 +1747,14 @@
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>

--- a/i18n/catroid_strings/values-tl/strings.xml
+++ b/i18n/catroid_strings/values-tl/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-tr/strings.xml
+++ b/i18n/catroid_strings/values-tr/strings.xml
@@ -138,7 +138,7 @@
     <string name="preference_title_accessibility_large_text">Büyük Metin</string>
     <string name="preference_title_accessibility_element_spacing">Büyük eleman aralığı</string>
     <string name="preference_description_accessibility_element_spacing">Listelerde öğe aralığını artırın.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop gecikmesi</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop gecikmesi</string>
     <string name="preference_description_accessibility_dragndrop_delay">Tuğlalar için sürükle bırak gecikmesi.</string>
     <string name="preference_title_accessibility_beginner_bricks">Başlangıç ​​modu</string>
     <string name="preference_description_accessibility_beginner_bricks">Yalnızca basit özellikleri göster</string>
@@ -163,7 +163,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 uzantısı</string>
     <string name="preference_description_quadcopter_bricks">Uygulamanın Parrot AR.Drone 2.0 quadcopters\'ı kontrol etmesine izin verin</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo uzantısı</string>
-    <string name="preference_description_jumpingsumo_bricks">Uygulamanın Parrot\'s Jumping Sumo robotlarını kontrol etmesine izin verin</string>
+    <string name="preference_description_jumpingsumo_bricks">Uygulamanın Parrot's Jumping Sumo robotlarını kontrol etmesine izin verin</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT uzantısı</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 uzantısı</string>
     <string name="preference_description_mindstorms_nxt_bricks">Uygulamanın Lego Mindstorms NXT robotlarını kontrol etmesine izin ver</string>

--- a/i18n/catroid_strings/values-tw/strings.xml
+++ b/i18n/catroid_strings/values-tw/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-uk/strings.xml
+++ b/i18n/catroid_strings/values-uk/strings.xml
@@ -108,12 +108,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -133,8 +133,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -152,7 +152,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -160,7 +160,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -168,8 +168,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -226,11 +226,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -324,7 +324,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -872,7 +872,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="few">layers</item>
@@ -949,12 +949,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -981,7 +981,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1288,9 +1288,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1320,11 +1320,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1671,7 +1671,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1848,7 +1848,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1908,21 +1908,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1965,7 +1965,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-ur/strings.xml
+++ b/i18n/catroid_strings/values-ur/strings.xml
@@ -892,7 +892,7 @@
     <string name="brick_speak_default_value">ہیلو!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">اور انتظار کریں</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1567,7 +1567,7 @@
     <string name="formula_editor_function_list_item_parameter">(* فہرست نام *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">مشتمل</string>
     <string name="formula_editor_function_contains_parameter">(* فہرست نام *)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(* فہرست نام *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">اشیاء کی تعداد</string>
     <string name="formula_editor_function_number_of_items_parameter">(* فہرست نام *)</string>
@@ -1813,7 +1813,7 @@
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">آپ کا پروجیکٹ ایپ  شراکت دار سائٹ پر اپ لوڈ ہو جاتا ہے جہاں دوسروں کو اس کا استعمال اور اسے ڈاؤن لوڈ کرسکتا ہے. آپ اپنے منصوبے کو ایک اسٹائل ایپ کے طور پر بھی ڈاؤن لوڈ کرسکتے ہیں.</string>
     <string name="progress_upload_dialog_failed">Upload failed. Please check your internet connection and try

--- a/i18n/catroid_strings/values-uz/strings.xml
+++ b/i18n/catroid_strings/values-uz/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -227,11 +227,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -313,7 +313,7 @@
     <string name="am_rename">Rename</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -801,7 +801,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="one">layer</item>
         <item quantity="other">layers</item>
@@ -874,12 +874,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Vibrate for</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -906,7 +906,7 @@
     <string name="brick_speak_default_value">Hello!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1203,9 +1203,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Something went wrong while uploading the project.</string>
     <string name="error_project_download">Something went wrong while downloading the project.</string>
@@ -1235,11 +1235,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1586,7 +1586,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
@@ -1763,7 +1763,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Compute</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Properties</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1823,21 +1823,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1880,7 +1880,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-vi/strings.xml
+++ b/i18n/catroid_strings/values-vi/strings.xml
@@ -113,12 +113,12 @@
     <!-- Settings activity -->
     <string name="preference_title">Cài đặt</string>
     <string name="preference_title_language">Language</string>
-    <string name="preference_description_language">Set the app\'s language</string>
+    <string name="preference_description_language">Set the app's language</string>
     <string name="preference_title_web_access">Web access</string>
     <string name="preference_description_web_access">Edit to add or remove trusted domains</string>
     <string name="preference_screen_web_access_title">Edit trusted domains</string>
     <string name="preference_title_accessibility">Accessibility</string>
-    <string name="preference_description_accessibility">Change the app\'s appearance</string>
+    <string name="preference_description_accessibility">Change the app's appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>
     <string name="preference_title_accessibility_profile">Predefined profiles</string>
     <string name="preference_title_accessibility_profile_headline">Profiles</string>
@@ -138,8 +138,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -157,7 +157,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -165,7 +165,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -173,8 +173,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -225,11 +225,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -305,7 +305,7 @@
     <string name="am_rename">Đổi Tên</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">Backpack</string>
@@ -763,7 +763,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="other">tầng lớp</item>
     </plurals>
@@ -834,12 +834,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">Rung</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -866,7 +866,7 @@
     <string name="brick_speak_default_value">Xin chào!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1158,9 +1158,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">Lỗi xảy ra trong khi tải lên chương trình.</string>
     <string name="error_project_download">Một lỗi xảy ra trong khi tải về chương trình.</string>
@@ -1190,11 +1190,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">Thiết bị ghép nối</string>
     <string name="title_other_devices">Thiết bị mới</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1541,7 +1541,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1, * danh sách tên *)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">bao gồm</string>
     <string name="formula_editor_function_contains_parameter">(* danh sách tên *, 1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1, * danh sách tên *)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">số_các_mục</string>
     <string name="formula_editor_function_number_of_items_parameter">(* danh sách tên *)</string>
@@ -1718,7 +1718,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">Tính toán</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">Đối tượng</string>
     <string name="formula_editor_intro_summary_object">This is a collection of values that describe the properties of your
@@ -1778,21 +1778,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1835,7 +1835,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>

--- a/i18n/catroid_strings/values-zh-rTW/strings.xml
+++ b/i18n/catroid_strings/values-zh-rTW/strings.xml
@@ -135,8 +135,8 @@
     <string name="preference_title_accessibility_large_text">Large text</string>
     <string name="preference_title_accessibility_element_spacing">Large element spacing</string>
     <string name="preference_description_accessibility_element_spacing">Increase element spacing in lists.</string>
-    <string name="preference_title_accessibility_dragndrop_delay">Drag\'n\'drop delay</string>
-    <string name="preference_description_accessibility_dragndrop_delay">Drag\'n\'drop delay for bricks.</string>
+    <string name="preference_title_accessibility_dragndrop_delay">Drag'n'drop delay</string>
+    <string name="preference_description_accessibility_dragndrop_delay">Drag'n'drop delay for bricks.</string>
     <string name="preference_title_accessibility_beginner_bricks">Beginner mode</string>
     <string name="preference_description_accessibility_beginner_bricks">Show only simple features.</string>
     <string name="preference_title_accessibility_font_style">Choose a text type</string>
@@ -154,7 +154,7 @@
     <string name="preference_access_summary_profile_odin">Large text, large icons, large element
        spacing, high contrast</string>
     <string name="preference_access_title_profile_fenrir">Fenrir</string>
-    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag\'n\'drop
+    <string name="preference_access_summary_profile_fenrir">Large element spacing, drag'n'drop
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
@@ -162,7 +162,7 @@
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>
     <string name="preference_description_quadcopter_bricks">Allow the app to control Parrot AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_jumpingsumo_bricks">Parrot Jumping Sumo extension</string>
-    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot\'s Jumping Sumo robots</string>
+    <string name="preference_description_jumpingsumo_bricks">Allow the app to control Parrot's Jumping Sumo robots</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT extension</string>
     <string name="preference_title_enable_mindstorms_ev3_bricks">Lego Mindstorms EV3 extension</string>
     <string name="preference_description_mindstorms_nxt_bricks">Allow the app to control Lego Mindstorms NXT robots</string>
@@ -170,8 +170,8 @@
     <string name="preference_title_mindstorms_nxt_sensors">Lego NXT Sensors</string>
     <string name="preference_title_mindstorms_ev3_sensors">Lego EV3 Sensors</string>
     <string name="preference_title_drone_config_properties">Parrot AR.Drone 2.0 configuration</string>
-    <string name="preference_title_enable_phiro_bricks">RobotixEdu\'s Phiro extension</string>
-    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu\'s Phiro robots</string>
+    <string name="preference_title_enable_phiro_bricks">RobotixEdu's Phiro extension</string>
+    <string name="preference_description_phiro_bricks">Allow the app to control RobotixEdu's Phiro robots</string>
     <string name="preference_title_enable_arduino_bricks">Arduino extension</string>
     <string name="preference_description_arduino_bricks">Allow the app to control Arduino boards</string>
     <string name="preference_title_enable_embroidery_bricks">Embroidery extension</string>
@@ -222,11 +222,11 @@
         <item quantity="other">You cannot convert more than %d projects at the same time. Please wait for the
             running conversions to finish first.</item>
     </plurals>
-    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn\'t
+    <string name="error_cannot_open_failed_scratch_program">You cannot open the project because it wasn't
         converted correctly. Please try to convert it again.</string>
     <string name="search_failed">Nothing found, please retry later.</string>
     <string name="connection_lost_or_closed_by_server">Server connection lost.</string>
-    <string name="connection_failed">We can\'t connect you to the server right now, please try again later.</string>
+    <string name="connection_failed">We can't connect you to the server right now, please try again later.</string>
     <string name="authentication_failed">There seems to be a problem with your connection to the service. Please
         contact the Catrobat team.</string>
     <plurals name="scratch_conversion_scheduled_x">
@@ -302,7 +302,7 @@
     <string name="am_rename">更名</string>
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
-    <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete">You can't undo this!</string>
     <string name="list_headline_sprites">Actors and objects</string>
     <!-- Options Menu Options -->
     <string name="backpack">背包</string>
@@ -760,7 +760,7 @@
     <string name="brick_set_rotation_style" tools:ignore="UnusedResources">"Set rotation style"</string>
     <string name="brick_set_rotation_style_lr" tools:ignore="UnusedResources">left-right only</string>
     <string name="brick_set_rotation_style_normal" tools:ignore="UnusedResources">all-around</string>
-    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don\'t rotate</string>
+    <string name="brick_set_rotation_style_no" tools:ignore="UnusedResources">don't rotate</string>
     <plurals name="brick_go_back_layer_plural">
         <item quantity="other">圖層</item>
     </plurals>
@@ -831,12 +831,12 @@
     <string name="brick_vibration" tools:ignore="UnusedResources">震動</string>
     <string name="brick_ask_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_store" tools:ignore="UnusedResources">and store written answer in</string>
-    <string name="brick_ask_default_question">What\'s your name?</string>
+    <string name="brick_ask_default_question">What's your name?</string>
     <string name="brick_ask_dialog_hint">"Enter your answer:"</string>
     <string name="brick_ask_dialog_submit">Submit answer</string>
     <string name="brick_ask_speech_label" tools:ignore="UnusedResources">Ask</string>
     <string name="brick_ask_speech_store" tools:ignore="UnusedResources">and store spoken answer in</string>
-    <string name="brick_ask_speech_default_question">What\'s your name?</string>
+    <string name="brick_ask_speech_default_question">What's your name?</string>
     <string name="brick_paint_new_look" tools:ignore="UnusedResources">Paint new look</string>
     <string name="brick_paint_new_background">Paint new background</string>
     <string name="brick_paint_new_look_name">"name of new look"</string>
@@ -863,7 +863,7 @@
     <string name="brick_speak_default_value">哈囉!</string>
     <string name="brick_speak_and_wait" tools:ignore="UnusedResources">and wait</string>
     <string name="brick_start_listening_to_voice" tools:ignore="UnusedResources">Start listening to voice and store spoken words in</string>
-    <string name="speech_recognition_not_available">Speech recognition isn\'t available.</string>
+    <string name="speech_recognition_not_available">Speech recognition isn't available.</string>
     <string name="speech_recognition_offline_mode_error_dialog_title">Missing offline data</string>
     <string name="speech_recognition_offline_mode_missing_data_error_dialog_msg">Offline speech recognition
     for %s is missing or needs to be updated. Would you like to download or update it now?</string>
@@ -1155,9 +1155,9 @@
     <!--  -->
     <!-- Runtime permission messages -->
     <string name="runtime_permission_general">This app needs the requested permissions to function properly. E.g., the
-Camera brick needs access to the device\'s camera, the \"location\" formula element needs access to the
-device\'s geolocation sensor, and in order to import and export projects from and to the local memory, the app
-needs read and write access to it. You can always change permissions through your device\'s settings.</string>
+Camera brick needs access to the device's camera, the \"location\" formula element needs access to the
+device's geolocation sensor, and in order to import and export projects from and to the local memory, the app
+needs read and write access to it. You can always change permissions through your device's settings.</string>
     <!-- Error messages -->
     <string name="error_project_upload">上傳程式檔時出錯。</string>
     <string name="error_project_download">下載程式檔時出錯。</string>
@@ -1187,11 +1187,11 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_set_notes_and_credits">Something went wrong while saving the new notes
         and credits.</string>
     <string name="error_no_whatsapp">WhatsApp not installed</string>
-    <string name="error_unsupported_bricks_chromecast">This script can\'t be added  to a Chromecast
+    <string name="error_unsupported_bricks_chromecast">This script can't be added  to a Chromecast
         project.</string>
     <!--  -->
     <!-- Bluetooth Connection Strings -->
-    <string name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string name="notification_blueth_err">Can't enable Bluetooth, please try turning it off and on again.</string>
     <string name="title_paired_devices">配對裝置</string>
     <string name="title_other_devices">新裝置</string>
     <string name="searching_devices">Looking for devices&#8230;</string>
@@ -1538,7 +1538,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_list_item_parameter">(1,*清單名稱*)</string>
     <string name="formula_editor_function_contains" tools:ignore="UnusedResources">contains</string>
     <string name="formula_editor_function_contains_parameter">(*清單名稱*,1)</string>
-    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item\'s index</string>
+    <string name="formula_editor_function_index_of_item" tools:ignore="UnusedResources">item's index</string>
     <string name="formula_editor_function_index_of_item_parameter">(1,*清單名稱*)</string>
     <string name="formula_editor_function_number_of_items" tools:ignore="UnusedResources">清單資料數</string>
     <string name="formula_editor_function_number_of_items_parameter">(*清單名稱*)</string>
@@ -1715,7 +1715,7 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_intro_summary_keyboard">This is where you can create
         your formula, just like on a calculator.</string>
     <string name="formula_editor_intro_title_compute">計算</string>
-    <string name="formula_editor_intro_summary_compute">To show your formula\'s current result, you can
+    <string name="formula_editor_intro_summary_compute">To show your formula's current result, you can
         use \"Compute\".</string>
     <string name="formula_editor_intro_title_object">物件</string>
     <string name="formula_editor_intro_summary_object">這個是描述當前物件的屬性值的集合。例如 x 和 y 坐標或當前的速度。</string>
@@ -1774,21 +1774,21 @@ needs read and write access to it. You can always change permissions through you
     <string name="cast_gamepad_left">left</string>
     <string name="cast_gamepad_right">right</string>
     <string name="cast_error_not_connected_msg">Please connect to your Chromecast first</string>
-    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can\'t be started
+    <string name="cast_error_cast_bricks_in_no_cast_project">Your project uses Chromecast bricks and can't be started
         locally</string>
     <string name="cast_device_selector_dialog_title">Cast to</string>
     <string name="cast_button_menu_item_title">Cast button</string>
     <string name="cast_ready_to_cast">Ready to cast to</string>
     <string name="cast_enable_cast_feature">Chromecast features disabled. Please enable cast features in the settings.</string>
     <string name="cast_searching_for_cast_devices">Searching for Chromecast devices</string>
-    <string name="cast_trouble_finding_devices_tip">.\nDon\'t see your device? Try turning your device\'s Wifi off
+    <string name="cast_trouble_finding_devices_tip">.\nDon't see your device? Try turning your device's Wifi off
         and on.</string>
     <string name="cast_connection_timout_msg">Connection timeout. Please try again.</string>
     <string name="cast_screen_pause_text">Paused</string>
     <!-- -->
     <string name="deletion_alert_title">Delete?</string>
     <string name="deletion_alert_text">Deleting a variable or list that is still in use can cause
-        errors. You can\'t undo this!</string>
+        errors. You can't undo this!</string>
     <!-- Upload progress dialog -->
     <string name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
@@ -1831,7 +1831,7 @@ needs read and write access to it. You can always change permissions through you
     <!-- Crash report dialog -->
     <!--  -->
     <!-- Multilingual List -->
-    <string name="device_language">Your device\'s language</string>
+    <string name="device_language">Your device's language</string>
     <!-- Symbols -->
     <string name="percent_symbol">%</string>
     <string name="hertz_symbol" tools:ignore="UnusedResources">㎐</string>


### PR DESCRIPTION
Update language strings so "\" is not shown wrong anymore.
https://jira.catrob.at/browse/BLOCKS-258

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
