### PR TITLE
[BLOCKS-267] Github Action: Catblocks Brick checker is broken

### DIFF
--- a/github_actions/catroid-support-checker-action/require/checker.py
+++ b/github_actions/catroid-support-checker-action/require/checker.py
@@ -70,15 +70,14 @@ def getBricksFromJsFileContent(jsContent):
 def loadCatroidBricks():
     global path
     base_dir = path
-    factory_path = base_dir + '/Catroid/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java'
+    factory_path = base_dir + '/Catroid/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.kt'
     file = open(factory_path, 'r')
     factory_file_lines = file.read().split('\n')
     java_bricks = []
     for line in factory_file_lines:
         if line.startswith('import org.catrobat.catroid.content.bricks.'):
             last_dot = line.rindex('.') + 1
-            line_end = line.rindex(';')
-            java_brick = line[last_dot: line_end]
+            java_brick = line[last_dot:]
             if java_brick not in excluded_java_bricks:
                 java_category = getCategoryForJavaBrick(java_brick)
                 java_bricks.append((java_brick, java_category))


### PR DESCRIPTION
Catroid Team changed `CategoryBricksFactory` from Java to Kotlin. Adapted Action to parse the new file.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed (Actions)
- [ ] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
