### PR TITLE
BLOCKS-250 Automatically fetch Language Updates from Catroid

### DIFF
--- a/github_actions/catroid-support-checker-action/action.yml
+++ b/github_actions/catroid-support-checker-action/action.yml
@@ -9,3 +9,17 @@ runs:
     image: 'Dockerfile'
     args: 
         - ${{ inputs.slack_webhook }}
+with:
+    add: '.'
+    message: 'Automatically fetch Language Updates from Catroid'
+    branch_mode: 'Language-Updates'
+
+on:
+    push:
+        branches:
+            - Language-Updates
+    pull_request:
+        branches:
+            - Language-Updates
+        base:
+            - develop

--- a/github_actions/catroid-support-checker-action/require/checker.py
+++ b/github_actions/catroid-support-checker-action/require/checker.py
@@ -228,7 +228,7 @@ def compareLanguageSupport(catroid_languages, catblocks_languages):
 
 def generateLanguageMessage(updated_languages):
     updated_languages.sort()
-    msg = '*Updated Languages*:\n'
+    msg = '*Automatically Updated Languages*:\n'
     for lang in updated_languages:
         msg += lang.replace('values-', '') + ', '
     return msg.strip().strip(',')
@@ -236,6 +236,25 @@ def generateLanguageMessage(updated_languages):
 def sendSlackMessage(webhook, message):
     json_data = {'text': message}
     requests.post(webhook, json=json_data)
+
+def fetchLanguages():
+    global path
+    base_dir = path + '/Catroid/catroid/src/main/res/'
+    copy_dir = path + '/Catblocks/i18n/catroid_strings/'
+    repo = git.Git(path + '/Catblocks')
+    git.Git(path + '/Catroid')
+    folders = os.listdir(base_dir)
+    languages = {}
+    for folder in folders:
+        xml_file = base_dir + folder + '/strings.xml'
+        if os.path.exists(xml_file):
+            if folder == 'values':
+                folder = folder + '-en'
+            cat_blocks_xml = copy_dir + folder + '/strings.xml'
+            os.replace(xml_file, cat_blocks_xml)
+        else:
+            languages[folder] = None
+
 
 
 # Requires the following Args: 
@@ -265,6 +284,7 @@ def main():
         language_updates = compareLanguageSupport(catroid_languages, catblocks_languages)
 
         if language_updates is not None and len(language_updates) > 0:
+            fetchLanguages()
             slack_msg += '\n\n' + generateLanguageMessage(language_updates)
             send_msg = True
 


### PR DESCRIPTION
Automatically fetch Language Updates from Catroid via Github Action
https://jira.catrob.at/browse/BLOCKS-250

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
