### PR TITLE
BLOCKS-282 Check automatically if all strings from string.xml are contained

### DIFF
--- a/github_actions/catroid-support-checker-action/require/checker.py
+++ b/github_actions/catroid-support-checker-action/require/checker.py
@@ -30,6 +30,24 @@ map_bricks_scripts = [
     ('WhenStartedBrick', 'StartScript'),
 ]
 
+bricksToCheck = [' Motion bricks ', ' Physics ', ' Look bricks ', ' Pen bricks ', ' Sound bricks ',
+                 ' Embroidery bricks ', ' Device bricks ', ' Control bricks ', ' Arduino Bricks ', ' Raspi Bricks ',
+                 ' Drone Bricks ', ' Jumping Sumo Bricks ', ' Phiro bricks ']
+
+ignoreStrings = ['brick_option_place_visually', 'brick_and_wait', 'brick_next_background', 'brick_previous_background',
+                 'brick_edit_background', 'brick_delete_background', 'brick_ask_default_question',
+                 'brick_ask_dialog_hint', 'brick_ask_dialog_submit', 'brick_ask_speech_default_question',
+                 'brick_paint_new_background', 'brick_paint_new_look_name', 'brick_copy_look_name',
+                 'brick_copy_background', 'brick_speak_default_value', 'speech_recognition_not_available',
+                 'speech_recognition_offline_mode_error_dialog_title',
+                 'speech_recognition_offline_mode_missing_data_error_dialog_msg', 'collision_with_anything',
+                 'brick_loop_end', 'brick_if_end', 'brick_write_variable_to_file_default_value',
+                 'brick_write_variable_to_file_success', 'brick_note_default_value', 'brick_think_bubble_default_value',
+                 'brick_say_bubble_default_value', 'brick_broadcast_default_value', 'brick_web_request_default_value',
+                 'web_request_warning_title', 'web_request_warning_message', 'web_request_trust_domain_warning_title',
+                 'web_request_trust_domain_warning_message', 'trusted_domains_edit_hint',
+                 'look_request_http_error_message', 'look_request_type_error_message', 'second_plural']
+
 # Loads the bricks supported by Catblocks from the JSON data.
 def loadCatblocksBricks():
     global path
@@ -233,6 +251,12 @@ def generateLanguageMessage(updated_languages):
         msg += lang.replace('values-', '') + ', '
     return msg.strip().strip(',')
 
+def generateStringsToJsonMessage(missing_strings):
+    missing_strings_in_json = str(missing_strings)
+    msg = '*Strings missing in strings_to_json_mapping.json*:\n'
+    msg += missing_strings_in_json.replace("[", "").replace("]", "").replace("'", "")
+    return msg
+
 def sendSlackMessage(webhook, message):
     json_data = {'text': message}
     requests.post(webhook, json=json_data)
@@ -257,7 +281,40 @@ def fetchLanguages():
         else:
             languages[folder] = None
 
+def checkStringsToJson():
+    global path
+    catblocks_language = path + '/Catblocks/i18n/catroid_strings/values-en/strings.xml'
+    catblocks_stringstojson = path + '/Catblocks/i18n/strings_to_json_mapping.json'
+    repo = git.Git(path + '/Catblocks')
+    catblocks_strings = []
 
+    if os.path.exists(catblocks_language):
+        parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+        tree = ET.parse(catblocks_language, parser=parser)
+        root = tree.getroot()
+        append_list = False
+        for line in root:
+            if "function Comment" in str(line.tag):
+                if line.text in bricksToCheck:
+                    append_list = True
+                else:
+                    append_list = False
+            if append_list:
+                text = str(line.items()).replace("[('name', '", "").replace("')]", "")
+                if text != '[]':
+                    catblocks_strings.append(text)
+
+    if os.path.exists(catblocks_stringstojson):
+        file = open(catblocks_stringstojson)
+        data = json.load(file)
+        check_list = catblocks_strings[:]
+        for string_line in catblocks_strings:
+            for json_line in data:
+                if (str(string_line)) in str(data[json_line]):
+                    check_list.remove(string_line)
+                    break
+        result = [x for x in check_list if x not in ignoreStrings]
+        return result
 
 # Requires the following Args: 
 #   [1] Path to the parent folder of Catblocks & Catroid project
@@ -284,6 +341,11 @@ def main():
         catroid_languages = loadSupportedCatroidLanguages()
         catblocks_languages = loadSupportedCatblocksLanguages()
         language_updates = compareLanguageSupport(catroid_languages, catblocks_languages)
+        catblocks_stringsToJson = checkStringsToJson()
+
+        if catblocks_stringsToJson is not None and len(catblocks_stringsToJson > 0):
+            slack_msg += '\n\n' + generateStringsToJsonMessage(catblocks_stringsToJson)
+            send_msg = True
 
         if language_updates is not None and len(language_updates) > 0:
             fetchLanguages()


### PR DESCRIPTION
checker.py checks now via github action if all necessary strings in strings.xml are in strings_to_json_mapping.json
https://jira.catrob.at/browse/BLOCKS-282
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
