### PR TITLE
BLOCKS-285 Checker.py failed to execute

### DIFF
--- a/github_actions/catroid-support-checker-action/require/checker.py
+++ b/github_actions/catroid-support-checker-action/require/checker.py
@@ -343,7 +343,7 @@ def main():
         language_updates = compareLanguageSupport(catroid_languages, catblocks_languages)
         catblocks_stringsToJson = checkStringsToJson()
 
-        if catblocks_stringsToJson is not None and len(catblocks_stringsToJson > 0):
+        if catblocks_stringsToJson is not None and len(catblocks_stringsToJson) > 0:
             slack_msg += '\n\n' + generateStringsToJsonMessage(catblocks_stringsToJson)
             send_msg = True
 


### PR DESCRIPTION
Fix the issue why checker.py fails to execute
https://jira.catrob.at/browse/BLOCKS-285

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
