### PR TITLE
BLOCKS-227 Restore place/brick in View when switching between 1D & 2D

### DIFF
--- a/src/library/js/integration/catroid.js
+++ b/src/library/js/integration/catroid.js
@@ -177,6 +177,8 @@ export class Catroid {
       }
     }
 
+    this.scrollToFocusBrick();
+
     this.workspace.addChangeListener(event => {
       if (event.type == Blockly.Events.BLOCK_DRAG && !event.isStart) {
         const droppedBrick = this.workspace.getBlockById(event.blockId);
@@ -242,6 +244,22 @@ export class Catroid {
         Android.removeBricks(event.ids);
       }
     });
+  }
+
+  scrollToFocusBrick() {
+    if (this.brickIDToFocus) {
+      const focusBrick = this.workspace.getBlockById(this.brickIDToFocus);
+      if (focusBrick) {
+        // this.workspace.centerOnBlock(this.brickIDToFocus);
+        const workspacePosition = focusBrick.getRelativeToSurfaceXY();
+        const pixelPosition = workspacePosition.scale(this.workspace.scale);
+        // const oldPositionX = pixelPosition.x;
+        // const oldPositionY = this.workspace.scrollY;
+        const improvedPositionX = -1 * (pixelPosition.x - 5);
+        const improvedPositionY = -1 * (pixelPosition.y - 5);
+        this.workspace.scroll(improvedPositionX, improvedPositionY);
+      }
+    }
   }
 
   domToSvgModifiable(blockJSON) {
@@ -361,5 +379,25 @@ export class Catroid {
         }
       }
     }
+  }
+
+  getBrickAtTopOfScreen() {
+    const allBricks = this.workspace.getAllBlocks(true);
+    const metrics = this.workspace.getMetrics();
+
+    const topLeftPixelCoords = new Blockly.utils.Coordinate(metrics.viewLeft, metrics.viewTop);
+    const topLeftWsCoords = topLeftPixelCoords.scale(1 / this.workspace.scale);
+
+    for (const brickIdx in allBricks) {
+      const brickPos = allBricks[brickIdx].getRelativeToSurfaceXY();
+      if (brickPos.y >= topLeftWsCoords.y) {
+        if (allBricks[brickIdx].type.endsWith('_UDB_CATBLOCKS_DEF')) {
+          continue;
+        }
+        // top brick
+        return allBricks[brickIdx].id;
+      }
+    }
+    return '';
   }
 }

--- a/src/library/js/lib_catroid.js
+++ b/src/library/js/lib_catroid.js
@@ -42,12 +42,13 @@ export class CatBlocks {
    *
    * @memberof CatBlocks
    */
-  static render(codeXML, showScene = null, showObject = null) {
+  static render(codeXML, showScene = null, showObject = null, brickIDToFocus = null) {
     $('#spinnerModal').one('shown.bs.modal', () => {
       try {
         const objectJSON = Parser.convertObjectToJSON(codeXML, showScene, showObject);
         catblocks_instance.share.scene = showScene;
         catblocks_instance.share.object = showObject;
+        catblocks_instance.share.brickIDToFocus = brickIDToFocus;
         catblocks_instance.share.renderObjectScripts(objectJSON);
       } finally {
         $('#spinnerModal').modal('hide');
@@ -74,5 +75,9 @@ export class CatBlocks {
    */
   static addBricks(bricks) {
     catblocks_instance.share.addBricks(bricks);
+  }
+
+  static getBrickAtTopOfScreen() {
+    return catblocks_instance.share.getBrickAtTopOfScreen();
   }
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-227
Focus correct brick when switching between 1D and 2D views.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
