### PR TITLE
BLOCKS-MAINTENANCE fix skipping tag message and windows launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "url": "http://localhost:8080",
             "webRoot": "${workspaceFolder}",
             "sourceMapPathOverrides": {
-                "webpack:///./*": "${workspaceFolder}/*"
+                "webpack:///./*": "${workspaceFolder}/*",
+                "webpack://catblocks/./*": "${workspaceFolder}/*"
             }
         },
         {

--- a/i18n/create_json.js
+++ b/i18n/create_json.js
@@ -2,7 +2,7 @@
 /* eslint-env node */
 
 /**
- * generate crowdin json files based on build mapping and string 
+ * generate crowdin json files based on build mapping and string
  * templates from catroid
  */
 
@@ -60,7 +60,10 @@ const parseStringFile = stream => {
         });
         break;
       default:
-        console.warn(`Skip not supported xml tag from ${STRINGS_FILE}`);
+        if (Object.keys(data[xmltag]).length === 1 && Object.keys(data[xmltag]).includes('xmlns:tools')) {
+          break;
+        }
+        console.warn(`Skip not supported xml tag from ${STRINGS_FILE}: ${xmltag}`);
         break;
     }
   });


### PR DESCRIPTION
Fix the annoying message that an XML Tag is not supported

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
