### PR TITLE
BLOCKS-291 Parameterized Brick message0 is wrong when multiple Lists are selected

### DIFF
--- a/i18n/strings_to_json_mapping.json
+++ b/i18n/strings_to_json_mapping.json
@@ -550,6 +550,7 @@
   "ASSERTION_PARAMETERIZED_BOTTOM": "${brick_parameterized_assert} %1%2 ${brick_parameterized_equals} %3%4",
   "ASSERTION_PARAMETERIZED_LIST_ONE": "${list_selection_plural.one}",
   "ASSERTION_PARAMETERIZED_LIST_OTHER": "${list_selection_plural.other}",
+  "ASSERTION_PARAMETERIZED_FOREACH_PLURAL": "${brick_parameterized_foreach_plural.other}",
   "ASSERTION_TAP_FOR": "${brick_touch_at} ${x_label} %1%2 ${y_label} %3%4 ${brick_tap_for} %5%6",
   "CAST_WHEN_GAMEPAD_BUTTON": "${brick_when_gamepad_button} %1%2 ${brick_when_gamepad_button_tapped}",
   "CLOSE": "${close}",

--- a/src/library/js/integration/utils.js
+++ b/src/library/js/integration/utils.js
@@ -362,6 +362,19 @@ export const renderBrick = (parentBrick, jsonBrick, brickListType, workspace) =>
         }
       }
     });
+    if (childBrick.type === 'ParameterizedBrick') {
+      try {
+        const dropdownString = childBrick.inputList[0].fieldRow[1].value_;
+        const numOfLists = parseInt(dropdownString.charAt(0));
+
+        if (numOfLists > 1) {
+          childBrick.inputList[0].fieldRow[0].value_ =
+            CatblocksMsgs.getCurrentLocaleValues()['ASSERTION_PARAMETERIZED_FOREACH_PLURAL'];
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
   }
 
   if (childBrick && childBrick.inputList && childBrick.inputList[0] && childBrick.inputList[0].fieldRow) {


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-291

Implemented changing of message0 to a plural version, when it is necessary. It is done in utils.js, as it is the only place in code, where it was possible. Respectively, a new string to JSON mapping has been added in order to be working in every language.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
