### PR TITLE
BLOCKS-304 Fix minifying of dev versions

### DIFF
--- a/webpack.release.build.config.js
+++ b/webpack.release.build.config.js
@@ -8,6 +8,9 @@ const releaseFolder = 'release' + (integrationTarget === 'share' ? '' : '_catroi
 
 module.exports = {
   mode: devMode ? 'development' : 'production',
+  optimization: {
+    minimize: !devMode
+  },
   entry: path.join(__dirname, `src/library/js/webpack_${integrationTarget}.js`),
   output: {
     filename: 'CatBlocks.js',

--- a/webpack.release.dev.config.js
+++ b/webpack.release.dev.config.js
@@ -7,6 +7,9 @@ const devMode = process.env.NODE_ENV !== 'production';
 
 module.exports = {
   mode: devMode ? 'development' : 'production',
+  optimization: {
+    minimize: !devMode
+  },
   entry: path.join(__dirname, 'src/library/js/webpack_share.js'),
   output: {
     filename: 'CatBlocks.js',
@@ -45,7 +48,7 @@ module.exports = {
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // all options are optional
-      filename:  '[name].css',
+      filename: '[name].css',
       chunkFilename: '[id].css',
       ignoreOrder: false, // Enable to remove warnings about conflicting order
     }),


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-304
Minifying didn't work anymore, because we forgot to add this option when the webpack version got updated.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
