### PR TITLE
BLOCKS-303 GH merge actions fail

### DIFF
--- a/github_actions/gh-deploy-new-develop-on-webtest/entrypoint.sh
+++ b/github_actions/gh-deploy-new-develop-on-webtest/entrypoint.sh
@@ -51,7 +51,7 @@ git commit -m "CATBLOCKS: update of catblocks folder"
 git push "https://${GITHUB_ACTOR}:${GITTOKEN}@github.com/Catrobat/Catroweb.git" ${BRANCH}
 RETVALUE=$(($? + $RETVALUE))
 echo $RETVALUE
-curl -i -H "Authorization: token ${GITTOKEN}" -X POST -d '{ "title": "Catblocks: New Release", "body": "Automatic deploy of new Catblocks version", "head": "gh_catblocks_automatic_deploy_develop", "base": "develop" }' https://api.github.com/repos/Catrobat/Catroweb/pulls | tac | tac | grep -qsE "201 Created|422 Unprocessable Entity"
+curl -s -o /dev/null -w "%{http_code}" -i -H "Authorization: token ${GITTOKEN}" -X POST -d '{ "title": "Catblocks: New Release", "body": "Automatic deploy of new Catblocks version", "head": "gh_catblocks_automatic_deploy_develop", "base": "develop" }' https://api.github.com/repos/Catrobat/Catroweb/pulls | tac | tac | grep -qsE "200|201|422"
 RETVALUE=$(($? + $RETVALUE))
 echo $RETVALUE
 

--- a/github_actions/gh-pages-deploy-action/entrypoint.sh
+++ b/github_actions/gh-pages-deploy-action/entrypoint.sh
@@ -7,13 +7,13 @@ Catblocks deploy testpage action
 PRNUMBER=$(python3 /PREvaluator.py)
 
 # go to checkout@v2 folder
+git config --global --add safe.directory /github/workspace
 cd /github/workspace/
 
 # build render
 yarn install
 yarn clean
 yarn render:ghpages
-RETVALUE="$?"
 
 mv ./dist ./../dist
 
@@ -34,6 +34,6 @@ git add ./develop
 git commit -m "$COMMITMSG"
 
 git push "https://${GITHUB_ACTOR}:${GITTOKEN}@github.com/Catrobat/Catblocks.git" "gh-pages"
-RETVALUE=$(($? + $RETVALUE))
-
-exit $RETVALUE
+PUSHRET=$?
+echo "Git Push exited with code $PUSHRET"
+exit $PUSHRET


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-303
Fix two GH merge actions:
- The action that creates a PR to Catroweb on merge to master.
- The action that merges the changes to gh-pages no merge to develop.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
