### PR TITLE
BLOCKS-318 Add ID to HTML elements for adding bricks

### DIFF
--- a/src/library/js/integration/catroid.js
+++ b/src/library/js/integration/catroid.js
@@ -147,7 +147,7 @@ export class Catroid {
       const $clickedElement = $(event.target);
 
       let $addBrickElement = $clickedElement;
-      if (!$clickedElement.hasClass('.catroid-category')) {
+      if (!$clickedElement.hasClass('catblocks-brick')) {
         $addBrickElement = $clickedElement.parents('.catblocks-brick');
       }
 
@@ -500,6 +500,8 @@ export class Catroid {
     for (const idx in categoryInfos) {
       const categoryColor = getColorForBrickCategory(categoryInfos[idx].name);
 
+      const categoryNameForID = categoryInfos[idx].name.replace(/\s/, '').toUpperCase();
+
       injectNewDom(
         'catroid-catblocks-brick-category-container',
         'button',
@@ -507,7 +509,8 @@ export class Catroid {
           class: 'list-group-item list-group-item-action catblocks-block-category-list-item',
           type: 'button',
           style: `background-color:${categoryColor};color:#fff;`,
-          categoryName: categoryInfos[idx].name
+          categoryName: categoryInfos[idx].name,
+          id: `category${categoryNameForID}`
         },
         categoryInfos[idx].name
       );
@@ -577,6 +580,7 @@ export class Catroid {
       svgContainer.setAttribute('class', 'catblocks-brick');
       svgContainer.setAttribute('catroid-category', categoryName);
       svgContainer.setAttribute('catroid-brickType', svgBlock.type);
+      svgContainer.setAttribute('id', `brick${svgBlock.type}`);
 
       const svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
       svgElement.setAttribute('style', `width:${blockWidth + 10}px;height:${blockHeight}px;`);


### PR DESCRIPTION
For creating unit tests for "add bricks", it's necessary that some HTML elements have an ID. (Categories and Bricks)

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
