### PR TITLE
BLOCKS-212 Looks are not shown as thumbnails, only after tapping on the magnifying glass

### DIFF
--- a/src/library/js/integration/utils.js
+++ b/src/library/js/integration/utils.js
@@ -480,7 +480,14 @@ export const changeSceneToRtl = (brick, workspace, sceneWidth) => {
  * @param {*} event
  */
 export const lazyLoadImage = event => {
-  const $objectHeader = $(event.target);
+  let $objectHeader = $(event.target);
+  let counter = 0;
+
+  while (!$objectHeader.attr('class').includes('card-header') && counter < 5) {
+    $objectHeader = $objectHeader.parent();
+    counter++;
+  }
+
   $objectHeader.off('click', lazyLoadImage);
 
   const $contentContainer = $objectHeader.next();

--- a/src/library/js/integration/utils.js
+++ b/src/library/js/integration/utils.js
@@ -481,11 +481,9 @@ export const changeSceneToRtl = (brick, workspace, sceneWidth) => {
  */
 export const lazyLoadImage = event => {
   let $objectHeader = $(event.target);
-  let counter = 0;
 
-  while (!$objectHeader.attr('class').includes('card-header') && counter < 5) {
-    $objectHeader = $objectHeader.parent();
-    counter++;
+  if (!$objectHeader.attr('class').includes('card-header')) {
+    $objectHeader = $objectHeader.parents('.card-header');
   }
 
   $objectHeader.off('click', lazyLoadImage);


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-212

Eventhandler didn't work accordingly, if the DOM element which fired the event was a subnode.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
