### PR TITLE
BLOCKS-314  [Adv. mode] Blocks change color when interacting

### DIFF
--- a/src/library/js/advanced_theme.json
+++ b/src/library/js/advanced_theme.json
@@ -1,7 +1,9 @@
 {
   "componentStyles": {
     "workspaceBackgroundColour": "#1a1a1a",
-    "scrollbarColour": "#2c2c2c"
+    "scrollbarColour": "#2c2c2c",
+    "selectedGlowColour": "#9a9a9a",
+    "insertionMarkerColour": "#7c7c7c"
   },
   "blockStyles": {
     "arduino": {

--- a/test/jsunit/catroid/integration.test.js
+++ b/test/jsunit/catroid/integration.test.js
@@ -116,4 +116,13 @@ describe('Catroid Integration Advanced Mode tests', () => {
 
     expect(allBlocksInAdvancedMode).toBe(true);
   });
+
+  test('Blocks select color test', async () => {
+    const selectedGlowColour = await page.evaluate(() => {
+      const blocks = document.querySelectorAll('.blocklyPath');
+      return blocks[0].tooltip.workspace.getTheme().componentStyles.selectedGlowColour;
+    });
+
+    expect(selectedGlowColour).toBe('#9a9a9a');
+  });
 });


### PR DESCRIPTION
4th PR to merge

Selected glow color adapted to advanced mode

https://jira.catrob.at/browse/BLOCKS-314

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
