### PR TITLE
BLOCKS-317 [Adv. mode] Fields inside of bricks should have the same color properties in terms of text and backgound

### DIFF
--- a/src/library/js/integration/catroid.js
+++ b/src/library/js/integration/catroid.js
@@ -634,5 +634,13 @@ export class Catroid {
   setAdvancedTheme() {
     const advTheme = Blockly.Theme.defineTheme('advancedTheme', advancedTheme);
     this.workspace.setTheme(advTheme);
+    const styleOfInputFields = document.createElement('style');
+    document.head.appendChild(styleOfInputFields);
+    styleOfInputFields.sheet.insertRule(
+      '.blocklyNonEditableText > rect:not(.blocklyDropdownRect), .blocklyEditableText > rect:not(.blocklyDropdownRect) {fill: #1a1a1a !important;}'
+    );
+    styleOfInputFields.sheet.insertRule(
+      '.blocklyNonEditableText > text, .blocklyEditableText > text, .blocklyNonEditableText > g > text, .blocklyEditableText > g > text {fill: #fff !important;}'
+    );
   }
 }

--- a/test/jsunit/catroid/integration.test.js
+++ b/test/jsunit/catroid/integration.test.js
@@ -125,4 +125,20 @@ describe('Catroid Integration Advanced Mode tests', () => {
 
     expect(selectedGlowColour).toBe('#9a9a9a');
   });
+
+  test('Input fields color test', async () => {
+    const inputFieldsInAdvancedMode = await page.evaluate(() => {
+      const inputFields = document.querySelectorAll('.blocklyEditableText > rect:not(.blocklyDropdownRect)');
+      let counter = 0;
+      let darkColor = true;
+      inputFields.forEach(field => {
+        darkColor = field.attributes.stroke.value === '#1a1a1a' && darkColor;
+        counter++;
+      });
+      darkColor = counter > 20 && darkColor;
+      return darkColor;
+    });
+
+    expect(inputFieldsInAdvancedMode).toBe(true);
+  });
 });


### PR DESCRIPTION
Adapted editable fields to advanced mode

https://jira.catrob.at/browse/BLOCKS-317

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
