### PR TITLE
BLOCKS-334  [Adv. mode] Adapt styling of bricks in the new dialog for adding new bricks

### DIFF
--- a/src/library/js/advanced_theme.json
+++ b/src/library/js/advanced_theme.json
@@ -1,7 +1,7 @@
 {
   "componentStyles": {
     "workspaceBackgroundColour": "#1a1a1a",
-    "scrollbarColour": "#2c2c2c",
+    "scrollbarColour": "#3c3c3c",
     "selectedGlowColour": "#9a9a9a",
     "insertionMarkerColour": "#7c7c7c"
   },

--- a/src/library/js/integration/catroid.js
+++ b/src/library/js/integration/catroid.js
@@ -18,7 +18,10 @@ import {
   buildUserDefinedBrick,
   injectNewDom,
   getMappedBrickNameIfExists,
-  getColorForBrickCategory
+  getColorForBrickCategory,
+  advancedModeAddSemicolonsAndClassifyTopBricks,
+  advancedModeAddParentheses,
+  advancedModeAddCurlyBrackets
 } from './utils';
 import { CatblocksMsgs } from '../catblocks_msgs';
 import advancedTheme from '../advanced_theme.json';
@@ -532,13 +535,17 @@ export class Catroid {
 
       const categoryNameForID = categoryInfos[idx].name.replace(/\s/, '').toUpperCase();
 
+      const categoryStyle = this.config.advancedMode
+        ? 'background-color:#3c3c3c;color:#b3b3b3;'
+        : `background-color:${categoryColor};color:#fff;`;
+
       injectNewDom(
         'catroid-catblocks-brick-category-container',
         'button',
         {
           class: 'list-group-item list-group-item-action catblocks-block-category-list-item',
           type: 'button',
-          style: `background-color:${categoryColor};color:#fff;`,
+          style: categoryStyle,
           categoryName: categoryInfos[idx].name,
           id: `category${categoryNameForID}`
         },
@@ -580,6 +587,11 @@ export class Catroid {
         }
 
         const brick = this.readonlyWorkspace.newBlock(brickType, brickInfo.brickId);
+        if (this.config.advancedMode) {
+          advancedModeAddParentheses(brick, true);
+          advancedModeAddCurlyBrackets(brick);
+          advancedModeAddSemicolonsAndClassifyTopBricks(brick);
+        }
         brick.initSvg();
       } catch (error) {
         console.log(error);
@@ -634,13 +646,22 @@ export class Catroid {
   setAdvancedTheme() {
     const advTheme = Blockly.Theme.defineTheme('advancedTheme', advancedTheme);
     this.workspace.setTheme(advTheme);
-    this.workspace.renderer_.constants_.DUMMY_INPUT_MIN_HEIGHT = 0; // Allows to change size of blocks
-    this.workspace.renderer_.constants_.MEDIUM_PADDING = 5; // Padding of block left & right
-    this.workspace.renderer_.constants_.FIELD_BORDER_RECT_HEIGHT = 14; // Determines height of block with input field
-    this.workspace.renderer_.constants_.FIELD_TEXT_HEIGHT = 14; // Determines height of a block without input field
-    this.workspace.renderer_.constants_.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 14; // Height of bottom part of e.g. 'if' block
-    this.workspace.renderer_.constants_.FIELD_BORDER_RECT_X_PADDING = 0;
-    this.workspace.renderer_.constants_.BETWEEN_STATEMENT_PADDING_Y = 0;
+    this.readonlyWorkspace.setTheme(advTheme);
+    this.workspace.getRenderer().constants_.DUMMY_INPUT_MIN_HEIGHT = 0; // Allows to change size of blocks
+    this.workspace.getRenderer().constants_.MEDIUM_PADDING = 5; // Padding of block left & right
+    this.workspace.getRenderer().constants_.FIELD_BORDER_RECT_HEIGHT = 14; // Determines height of block with input field
+    this.workspace.getRenderer().constants_.FIELD_TEXT_HEIGHT = 14; // Determines height of a block without input field
+    this.workspace.getRenderer().constants_.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 14; // Height of bottom part of e.g. 'if' block
+    this.workspace.getRenderer().constants_.FIELD_BORDER_RECT_X_PADDING = 0;
+    this.workspace.getRenderer().constants_.BETWEEN_STATEMENT_PADDING_Y = 0;
+    this.readonlyWorkspace.getRenderer().constants_.BETWEEN_STATEMENT_PADDING_Y = 0;
+    this.readonlyWorkspace.getRenderer().constants_.DUMMY_INPUT_MIN_HEIGHT = 0;
+    this.readonlyWorkspace.getRenderer().constants_.MEDIUM_PADDING = 5;
+    this.readonlyWorkspace.getRenderer().constants_.FIELD_BORDER_RECT_HEIGHT = 30;
+    this.readonlyWorkspace.getRenderer().constants_.FIELD_TEXT_HEIGHT = 30;
+    this.readonlyWorkspace.getRenderer().constants_.BOTTOM_ROW_AFTER_STATEMENT_MIN_HEIGHT = 30;
+    this.readonlyWorkspace.getRenderer().constants_.FIELD_BORDER_RECT_X_PADDING = 0;
+
     const styleOfInputFields = document.createElement('style');
     document.head.appendChild(styleOfInputFields);
     styleOfInputFields.sheet.insertRule(
@@ -649,6 +670,13 @@ export class Catroid {
     styleOfInputFields.sheet.insertRule(
       '.blocklyNonEditableText > text, .blocklyEditableText > text, .blocklyNonEditableText > g > text, .blocklyEditableText > g > text {fill: #fff !important;}'
     );
+    styleOfInputFields.sheet.insertRule('#catroid-catblocks-add-brick-dialog {background-color: #1a1a1a !important;}');
     styleOfInputFields.sheet.insertRule('.blocklyMainBackground {stroke-width: 0 !important;}');
+    const brickContainer = document.getElementById('catroid-catblocks-bricks-container');
+    const headerContainer = document.getElementById('catroid-catblocks-add-brick-dialog-header');
+    const textContainer = document.getElementById('catroid-catblocks-add-brick-text-container');
+    brickContainer.setAttribute('class', 'zelos-renderer advancedtheme-theme');
+    headerContainer.setAttribute('style', 'background-color: #3c3c3c');
+    textContainer.setAttribute('style', 'color: #b3b3b3');
   }
 }

--- a/src/library/js/integration/utils.js
+++ b/src/library/js/integration/utils.js
@@ -672,16 +672,16 @@ export const getColorForBrickCategory = categoryName => {
   return '#aaaaaa';
 };
 
-function advancedModeAddParentheses(childBrick) {
-  if (childBrick.type === 'NoteBrick' || childBrick.type === 'UserDefinedScript') {
+export function advancedModeAddParentheses(childBrick, addBrickDialog = false) {
+  if (childBrick.type === 'UserDefinedScript' && !addBrickDialog) {
     return;
   }
   for (const input of childBrick.inputList) {
     for (let field = 1; field < input.fieldRow.length; field++) {
       if (input.fieldRow[field].EDITABLE) {
-        const newVal = input.fieldRow[field - 1].getValue() + ' (';
-        input.fieldRow[field - 1].setValue(newVal);
-        advancedModeRemoveWhiteSpacesInFormulas(input.fieldRow[field]);
+        if (addBrickDialog) {
+          input.fieldRow[field].setValue('...');
+        }
 
         if (input.fieldRow[field + 1].name && input.fieldRow[field + 1].name.endsWith('_INFO')) {
           const sourceBlock = input.fieldRow[field + 1].getSourceBlock();
@@ -689,13 +689,21 @@ function advancedModeAddParentheses(childBrick) {
           labelField.setSourceBlock(sourceBlock);
           input.fieldRow[field + 1] = labelField;
           input.fieldRow[field + 1].setValue(')');
+
+          if (childBrick.type === 'NoteBrick') {
+            input.fieldRow[field + 1].setValue('');
+            return;
+          }
         }
+        advancedModeRemoveWhiteSpacesInFormulas(input.fieldRow[field]);
+        const newVal = input.fieldRow[field - 1].getValue() + ' (';
+        input.fieldRow[field - 1].setValue(newVal);
       }
     }
   }
 }
 
-function advancedModeAddCurlyBrackets(childBrick) {
+export function advancedModeAddCurlyBrackets(childBrick) {
   if (childBrick.inputList.some(field => field.name === 'SUBSTACK')) {
     const sourceBlock = childBrick.inputList[0].getSourceBlock();
     const labelField = new Blockly.FieldLabel('}');
@@ -713,7 +721,7 @@ function advancedModeAddCurlyBrackets(childBrick) {
       childBrick.inputList[4].fieldRow[0] = labelField;
       childBrick.inputList[4].fieldRow[0].setValue('}');
     }
-    if (childBrick.inputList.length === 3) {
+    if (childBrick.inputList.length === 3 && childBrick.type !== 'ParameterizedBrick') {
       childBrick.inputList[2].setAlign(Blockly.ALIGN_LEFT);
       childBrick.inputList[2].fieldRow[0] = labelField;
     }
@@ -732,7 +740,7 @@ function advancedModeAddCurlyBrackets(childBrick) {
   }
 }
 
-function advancedModeAddSemicolonsAndClassifyTopBricks(childBrick) {
+export function advancedModeAddSemicolonsAndClassifyTopBricks(childBrick) {
   if (
     childBrick.type === 'NoteBrick' ||
     childBrick.type === 'UserDefinedScript' ||


### PR DESCRIPTION
Adapt catblocks add brick dialog colors to the advanced mode

https://jira.catrob.at/browse/BLOCKS-334

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
