### PR TITLE
BLOCKS-349 GitHub Support Checker Action reports wrong bricks

### DIFF
--- a/github_actions/catroid-support-checker-action/require/checker.py
+++ b/github_actions/catroid-support-checker-action/require/checker.py
@@ -28,6 +28,10 @@ map_bricks_scripts = [
     ('WhenClonedBrick', 'WhenClonedScript'),
     ('WhenTouchDownBrick', 'WhenTouchDownScript'),
     ('WhenStartedBrick', 'StartScript'),
+    ('EmptyEventBrick', 'EmptyScript'),
+    ('WhenRaspiPinChangedBrick', 'RaspiInterruptScript'),
+    ('WhenNfcBrick', 'WhenNfcScript'),
+    ('WhenGamepadButtonBrick', 'WhenGamepadButtonScript')
 ]
 
 bricksToCheck = [' Motion bricks ', ' Physics ', ' Look bricks ', ' Pen bricks ', ' Sound bricks ',

--- a/src/library/js/blocks/categories/event.js
+++ b/src/library/js/blocks/categories/event.js
@@ -69,38 +69,5 @@ export default {
         name: 'look_INFO'
       }
     ]
-  },
-  RaspiInterruptScript: {
-    message0: '%{BKY_EVENT_RASPI_INTERRUPT_SCRIPT}',
-    args0: [
-      {
-        type: 'field_catblocksspinner',
-        catroid_field_id: 'brick_raspi_when_pinspinner',
-        name: 'pin'
-      },
-      {
-        type: 'field_image',
-        src: `${document.location.pathname}media/info_icon.svg`,
-        height: 24,
-        width: 24,
-        alt: '(i)',
-        flip_rtl: true,
-        name: 'pin_INFO'
-      },
-      {
-        type: 'field_catblocksspinner',
-        catroid_field_id: 'brick_raspi_when_valuespinner',
-        name: 'eventValue'
-      },
-      {
-        type: 'field_image',
-        src: `${document.location.pathname}media/info_icon.svg`,
-        height: 24,
-        width: 24,
-        alt: '(i)',
-        flip_rtl: true,
-        name: 'eventValue_INFO'
-      }
-    ]
   }
 };

--- a/src/library/js/blocks/categories/script.js
+++ b/src/library/js/blocks/categories/script.js
@@ -19,5 +19,38 @@ export default {
         name: 'ACTION_INFO'
       }
     ]
+  },
+  RaspiInterruptScript: {
+    message0: '%{BKY_EVENT_RASPI_INTERRUPT_SCRIPT}',
+    args0: [
+      {
+        type: 'field_catblocksspinner',
+        catroid_field_id: 'brick_raspi_when_pinspinner',
+        name: 'pin'
+      },
+      {
+        type: 'field_image',
+        src: `${document.location.pathname}media/info_icon.svg`,
+        height: 24,
+        width: 24,
+        alt: '(i)',
+        flip_rtl: true,
+        name: 'pin_INFO'
+      },
+      {
+        type: 'field_catblocksspinner',
+        catroid_field_id: 'brick_raspi_when_valuespinner',
+        name: 'eventValue'
+      },
+      {
+        type: 'field_image',
+        src: `${document.location.pathname}media/info_icon.svg`,
+        height: 24,
+        width: 24,
+        alt: '(i)',
+        flip_rtl: true,
+        name: 'eventValue_INFO'
+      }
+    ]
   }
 };


### PR DESCRIPTION
Add missing bricks to mapping in catroid-support-checker-action.
Change RaspiInterruptScript from event to scripts.
https://jira.catrob.at/browse/BLOCKS-349

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
