### PR TITLE
BLOCKS-332 CSS Class Duplicates/Conflicts

### DIFF
--- a/src/library/js/integration/share.js
+++ b/src/library/js/integration/share.js
@@ -213,7 +213,7 @@ export class Share {
       sceneHeader,
       'button',
       {
-        class: 'accordion-button collapsed',
+        class: 'catblocks-accordion-button collapsed',
         type: 'button',
         'data-bs-toggle': 'collapse',
         'data-bs-target': `#${sceneID}-collapseOne`,
@@ -459,7 +459,7 @@ export class Share {
     });
 
     const headerButton = generateNewDOM(cardHeader, 'button', {
-      class: 'accordion-button collapsed ps-sm-5',
+      class: 'catblocks-accordion-button collapsed ps-sm-5',
       type: 'button',
       'data-bs-toggle': 'collapse',
       'data-bs-target': `#${objCollapseOneSceneID}`,
@@ -880,7 +880,7 @@ export class Share {
     );
 
     const ul = generateNewDOM(container, 'ul', {
-      class: 'nav nav-tabs nav-fill catro-tabs',
+      class: 'nav nav-tabs nav-fill catblocks-tabs',
       id: `${objectID}-tabs`,
       role: 'tablist'
     });

--- a/src/library/scss/share.scss
+++ b/src/library/scss/share.scss
@@ -36,7 +36,7 @@
     border-right: 4px solid $primary;
   }
 
-  .catro-tabs {
+  .catblocks-tabs {
     height: 100%;
 
     .nav-link {
@@ -55,10 +55,11 @@
     }
   }
 
-  .accordion-button {
+  .catblocks-accordion-button {
     &:not(.collapsed) {
       font-weight: bold;
     }
+    @extend .accordion-button
   }
 
   .catblocks-object-look-row,
@@ -98,6 +99,6 @@
   }
 }
 
-.search {
+.catblocks-search {
   width: 3em;
 }

--- a/test/jsunit/share/share.test.js
+++ b/test/jsunit/share/share.test.js
@@ -792,7 +792,7 @@ describe('Share catroid program rendering tests', () => {
     expect(beforeClickSrc).toBeNull();
 
     // open object
-    await page.click(`#${objID}-header .accordion-button`);
+    await page.click(`#${objID}-header .catblocks-accordion-button`);
     // wait for tabs to be visible
     await page.waitForSelector(`#${objID}-tabs`);
 
@@ -1032,7 +1032,7 @@ describe('Share catroid program rendering tests', () => {
       sceneName
     );
 
-    const identifier = '.catblocks-scene .accordion-header .accordion-button';
+    const identifier = '.catblocks-scene .accordion-header .catblocks-accordion-button';
     const cardHeaderInitialText = await page.$eval(identifier, x => x.innerHTML);
     expect(cardHeaderInitialText).toBe(programID);
 
@@ -1281,7 +1281,7 @@ describe('Share catroid program rendering tests', () => {
       Test.Share.config.renderLooks = true;
     }, catObj);
 
-    const tabs = await page.$$('.catro-tabs .nav-item');
+    const tabs = await page.$$('.catblocks-tabs .nav-item');
     expect(tabs).toHaveLength(2);
   });
 


### PR DESCRIPTION
Change some CSS class names by adding 'catblocks-' as a prefix. For the 'accordion-button' the @extend is used to change its name to 'catblocks-accordion-button'.

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
