### PR TITLE
BLOCKS-350 add Playground.ts wrapper

### DIFF
--- a/src/intern/ts/Playground.ts
+++ b/src/intern/ts/Playground.ts
@@ -1,0 +1,31 @@
+import '../scss/style.scss';
+
+import { Playground } from '../js/playground/playground';
+import Blockly from 'blockly';
+import { CatBlocksMsgs } from '../../library/ts/i18n/CatBlocksMsgs';
+import { CatBlocksConfig } from '../../library/ts/config/CatBlocksConfig';
+import { ConfigValidator } from '../../library/ts/config/ConfigValidator';
+
+declare global {
+  interface Window {
+    Catblocks: Playground;
+    Blockly: typeof Blockly;
+  }
+}
+
+(async function () {
+  const config: Partial<CatBlocksConfig> = {
+    language: process.env.DISPLAY_LANGUAGE,
+    rtl: process.env.DISPLAY_RTL?.toLowerCase() === 'true',
+    container: 'catblocks-workspace-container',
+    shareRoot: '/'
+  };
+  const validatedConfig = ConfigValidator.parseOptions(config);
+
+  CatBlocksMsgs.init(validatedConfig.i18n);
+  await CatBlocksMsgs.setLocale('en');
+  window.Blockly = Blockly;
+  const playground = new Playground();
+  playground.init();
+  window.Catblocks = playground;
+})();


### PR DESCRIPTION
https://jira.catrob.at/browse/BLOCKS-350
Added a wrapper named Playground.ts to include playground.js, so we can at least use it again for now

### Your checklist for this pull request
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Make sure you use BLOCKS instead of CATROID in your commit message
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed (Actions)
- [x] Post a message in the *#catblocks* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
